### PR TITLE
Fix zombie sometimes not damaging the player

### DIFF
--- a/Enemy/Zombie.gd
+++ b/Enemy/Zombie.gd
@@ -19,4 +19,9 @@ func _ready() -> void:
 func _physics_process(delta: float) -> void:
 	var direction_to_player = (player.transform.origin - transform.origin).normalized()
 	velocity.y = -gravity
-	velocity = move_and_slide(movement_speed * direction_to_player)
+	var collision = move_and_collide(movement_speed * direction_to_player * delta)
+	if collision and collision.collider is Player:
+		_damage_player(collision.collider)
+
+func _damage_player(player: Player) -> void:
+	player.on_damaged_by(self)

--- a/Player/Player.gd
+++ b/Player/Player.gd
@@ -50,7 +50,6 @@ func _on_item_near(item: PhysicsBody) -> void:
 
 func _process(delta: float) -> void:
 	_rotate_body()
-	damage_cooldown -= delta
 
 func _physics_process(delta: float) -> void:
 	if is_shooting:
@@ -69,12 +68,9 @@ func _physics_process(delta: float) -> void:
 	velocity.y = -gravity
 	velocity = move_and_slide(velocity)
 	
-	for i in range(get_slide_count()):
-		var collision := get_slide_collision(i)
-		if collision.collider is Enemy:
-			_on_damaged_by(collision.collider)
+	damage_cooldown -= delta
 
-func _on_damaged_by(entity: Enemy) -> void:
+func on_damaged_by(entity: Enemy) -> void:
 	if damage_cooldown <= 0:
 		damage_cooldown = damage_interval
 		var old_health := health


### PR DESCRIPTION
As described in #1, the bug is because the collision is only counted when the player slides against the zombie. This may sometimes not happen, mainly when the player's corner touches the zombie.

This fix changes the collision to be done by the enemy instead. This is consistent anyways with the case of bullet detecting the zombie. In the future where enemies can shoot, we also cannot rely on the `get_slide_count()` function to detect damage.