### PR TITLE
Add damage numbers, refactor HealthBar to its own scene

### DIFF
--- a/Bullet/Bullet.gd
+++ b/Bullet/Bullet.gd
@@ -1,12 +1,16 @@
 extends KinematicBody
 class_name Bullet
 
+const DamageNumber := preload("res://GUI/DamageNumber/DamageNumber.tscn")
+
 const _DECAY_DELTA := 2.0
 const _SPEED := 100
-const _DAMAGE := 30
+const _MEAN_DAMAGE := 30.0
+const _SPREAD := 10.0
 
+onready var _level_manager = get_tree().get_root().find_node("LevelManager", true, false)
 var timer: float = 0.0
-	
+
 func _process(delta: float) -> void:
 	timer += delta
 	if timer > _DECAY_DELTA:
@@ -17,5 +21,21 @@ func _physics_process(delta: float) -> void:
 	var collision := move_and_collide(velocity * delta)
 	if collision:
 		if collision.collider.is_in_group("enemies") or collision.collider.is_in_group("crates"):
-			collision.collider.on_damaged(_DAMAGE)
+			var damage = _get_damage()
+			collision.collider.on_damaged(damage)
+			var effectiveness = (damage - (_MEAN_DAMAGE - _SPREAD / 2)) / _SPREAD
+			_show_damage_number(damage, effectiveness)
 			queue_free()
+
+func _get_damage() -> int:
+	var lower_bound = _MEAN_DAMAGE - _SPREAD / 2
+	var upper_bound = _MEAN_DAMAGE + _SPREAD / 2
+	var damage_float := randf() * _SPREAD + _MEAN_DAMAGE - _SPREAD / 2
+	return int(round(damage_float))
+
+func _show_damage_number(damage: int, effectiveness: float) -> void:
+	var damage_number := DamageNumber.instance()
+	damage_number.set_damage(damage)
+	damage_number.set_damage_effectiveness(effectiveness)
+	damage_number.global_transform.origin = global_transform.origin
+	_level_manager.add_child(damage_number)

--- a/Bullet/Bullet.gd
+++ b/Bullet/Bullet.gd
@@ -22,20 +22,18 @@ func _physics_process(delta: float) -> void:
 	if collision:
 		if collision.collider.is_in_group("enemies") or collision.collider.is_in_group("crates"):
 			var damage = _get_damage()
-			collision.collider.on_damaged(damage)
 			var effectiveness = (damage - (_MEAN_DAMAGE - _SPREAD / 2)) / _SPREAD
-			_show_damage_number(damage, effectiveness)
+			collision.collider.on_damaged(damage)
+			_show_damage_number(collision.collider.global_transform.origin, damage, effectiveness)
 			queue_free()
 
 func _get_damage() -> int:
-	var lower_bound = _MEAN_DAMAGE - _SPREAD / 2
-	var upper_bound = _MEAN_DAMAGE + _SPREAD / 2
-	var damage_float := randf() * _SPREAD + _MEAN_DAMAGE - _SPREAD / 2
+	var damage_float := _MEAN_DAMAGE + (randf() - 0.5) * _SPREAD
 	return int(round(damage_float))
 
-func _show_damage_number(damage: int, effectiveness: float) -> void:
+func _show_damage_number(position: Vector3, damage: int, effectiveness: float) -> void:
 	var damage_number := DamageNumber.instance()
 	damage_number.set_damage(damage)
 	damage_number.set_damage_effectiveness(effectiveness)
-	damage_number.global_transform.origin = global_transform.origin
+	damage_number.global_transform.origin = position
 	_level_manager.add_child(damage_number)

--- a/Bullet/Bullet.gd
+++ b/Bullet/Bullet.gd
@@ -33,7 +33,8 @@ func _get_damage() -> int:
 
 func _show_damage_number(position: Vector3, damage: int, effectiveness: float) -> void:
 	var damage_number := DamageNumber.instance()
+	var transform_offset := Vector3(randf() * damage_number.SPAWN_OFFSET_RANGE, 0, randf() * damage_number.SPAWN_OFFSET_RANGE)
 	damage_number.set_damage(damage)
 	damage_number.set_damage_effectiveness(effectiveness)
-	damage_number.global_transform.origin = position
+	damage_number.global_transform.origin = position + transform_offset
 	_level_manager.add_child(damage_number)

--- a/Crate/HealthBar.gd
+++ b/Crate/HealthBar.gd
@@ -5,7 +5,7 @@ const Crate = preload("res://Crate/Crate.gd")
 var _initialized := false
 
 func _ready() -> void:
-	var entity = $".."
+	var entity = get_parent()
 	entity.connect("health_changed", self, "_on_health_changed")
 
 func _physics_process(delta: float) -> void:

--- a/Enemy/Enemy.gd
+++ b/Enemy/Enemy.gd
@@ -24,10 +24,11 @@ func _health_get() -> int:
 func on_damaged(damage: int) -> void:
 	var old_health := health
 	health -= damage
+
 	emit_signal("health_changed", self, old_health)
 	if health <= 0:
 		_die()
-		
+
 func generate_drops() -> Array:
 	push_error("generate_drops not implemented by %s" % filename)
 	return []

--- a/Enemy/Enemy.tscn
+++ b/Enemy/Enemy.tscn
@@ -1,14 +1,7 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=3 format=2]
 
 [ext_resource path="res://Enemy/Enemy.gd" type="Script" id=1]
-[ext_resource path="res://Enemy/HealthBar.gd" type="Script" id=2]
-[ext_resource path="res://GUI/PlayerHealthBar/healthbarfront.png" type="Texture" id=3]
-[ext_resource path="res://GUI/PlayerHealthBar/healthbarback.png" type="Texture" id=4]
-
-[sub_resource type="SpatialMaterial" id=1]
-flags_transparent = true
-flags_unshaded = true
-params_billboard_mode = 1
+[ext_resource path="res://GUI/EnemyHealthBar/HealthBar.tscn" type="PackedScene" id=2]
 
 [node name="Enemy" type="KinematicBody"]
 transform = Transform( 1.5, 0, 0, 0, 1, 0, 0, 0, 1.5, 0, 0, 0 )
@@ -16,19 +9,4 @@ collision_layer = 2
 collision_mask = 3
 script = ExtResource( 1 )
 
-[node name="HealthBar" type="Sprite3D" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.62991, 0 )
-material_override = SubResource( 1 )
-script = ExtResource( 2 )
-
-[node name="ProgressBar" type="TextureProgress" parent="HealthBar"]
-margin_right = 536.0
-margin_bottom = 77.0
-rect_scale = Vector2( 0.1, 0.1 )
-texture_under = ExtResource( 4 )
-texture_progress = ExtResource( 3 )
-__meta__ = {
-"_edit_use_anchors_": false
-}
-
-[node name="Tween" type="Tween" parent="HealthBar"]
+[node name="HealthBar" parent="." instance=ExtResource( 2 )]

--- a/Enemy/HealthBar.gd
+++ b/Enemy/HealthBar.gd
@@ -5,7 +5,7 @@ const Enemy = preload("res://Enemy/Enemy.gd")
 var _initialized := false
 
 func _ready() -> void:
-	var entity = $".."
+	var entity = get_parent()
 	entity.connect("health_changed", self, "_on_health_changed")
 
 func _physics_process(delta: float) -> void:

--- a/Fonts/DamageNumber.tres
+++ b/Fonts/DamageNumber.tres
@@ -3,7 +3,7 @@
 [ext_resource path="res://Fonts/GloriaHallelujah-Regular.ttf" type="DynamicFontData" id=1]
 
 [resource]
-size = 35
+size = 60
 outline_size = 3
 outline_color = Color( 0, 0, 0, 1 )
 font_data = ExtResource( 1 )

--- a/Fonts/DamageNumber.tres
+++ b/Fonts/DamageNumber.tres
@@ -1,0 +1,9 @@
+[gd_resource type="DynamicFont" load_steps=2 format=2]
+
+[ext_resource path="res://Fonts/GloriaHallelujah-Regular.ttf" type="DynamicFontData" id=1]
+
+[resource]
+size = 35
+outline_size = 3
+outline_color = Color( 0, 0, 0, 1 )
+font_data = ExtResource( 1 )

--- a/GUI/DamageNumber/DamageNumber.gd
+++ b/GUI/DamageNumber/DamageNumber.gd
@@ -1,17 +1,19 @@
 extends Sprite3D
 
-const _LIFETIME := 1.0
+const _LIFETIME := 0.75
 const _SPEED := 5
 
 var _damage: int
-var _direction = Vector3(1, 0, 1)
+var _effectiveness: float
+var _direction = Vector3(1, 0, 0)
 var _total_delta: float = 0
 var _color: Color
 
 onready var _label = $Label
 
 func _ready() -> void:
-	var entity = get_parent()
+	$Label.rect_pivot_offset = $Label.rect_size / 2
+	_update(0)
 
 func set_damage(damage: int):
 	_damage = damage
@@ -24,6 +26,7 @@ func set_damage_effectiveness(effectiveness: float) -> void:
 		_color = Color.orange
 	else:
 		_color = Color.red
+	_effectiveness = effectiveness
 	$Label.modulate = _color
 
 func _physics_process(delta: float) -> void:
@@ -31,13 +34,20 @@ func _physics_process(delta: float) -> void:
 	if _total_delta > _LIFETIME:
 		queue_free()
 	else:
-		var progress = _total_delta / _LIFETIME
-		var pos = get_global_transform().origin
-		var cam = get_tree().get_root().get_camera()
-		var screen_pos = cam.unproject_position(pos)
-		var size = _label.get_size()
-		var scale = _label.get_scale()
-		var position = screen_pos + Vector2(0, -size.y * scale.y)
-		_label.set_position(position)
-		_label.modulate.a = 1.0 - progress
-		translation += _direction * delta * _SPEED
+		_update(delta)
+
+func _update(delta: float) -> void:
+	var progress = _total_delta / _LIFETIME
+	var pos = get_global_transform().origin
+	var cam = get_tree().get_root().get_camera()
+	var screen_pos = cam.unproject_position(pos)
+	var position = screen_pos - Vector2(_label.rect_size.x * 0.5, _label.rect_size.y * 0.75)
+	
+	var progress_scale_factor = 1.0 - progress / 2
+	var effectiveness_scale_factor = 0.5 + 0.5 * _effectiveness
+	var scale_factor = progress_scale_factor * effectiveness_scale_factor
+	
+	_label.set_position(position)
+	_label.modulate.a = 1.0 - progress
+	_label.rect_scale = Vector2(scale_factor, scale_factor)
+	translation += _direction * delta * _SPEED

--- a/GUI/DamageNumber/DamageNumber.gd
+++ b/GUI/DamageNumber/DamageNumber.gd
@@ -39,19 +39,21 @@ func _physics_process(delta: float) -> void:
 	else:
 		_update(delta)
 
-func _update(delta: float) -> void:
+func _update_2d_position() -> void:
 	var pos = get_global_transform().origin
 	var cam = get_tree().get_root().get_camera()
 	var screen_pos = cam.unproject_position(pos)
 	var position = screen_pos - Vector2(_label.rect_size.x * 0.5, _label.rect_size.y * 0.75)
-	
+	_label.set_position(position)
+
+func _update(delta: float) -> void:
+	_update_2d_position()
 	var time_scale_factor = clamp(_total_delta / _APPEAR_DURATION, 0, 1)
 	var effectiveness_scale_factor = 0.5 + 0.5 * pow(_effectiveness, 2)
 	var scale_factor = time_scale_factor * effectiveness_scale_factor
-	
 	var time_left = _LIFETIME - _total_delta
 	var opacity = clamp(time_left / _DISAPPEAR_DURATION, 0, 1)
-	_label.set_position(position)
+	
 	_label.modulate.a = opacity
 	_label.rect_scale = Vector2(scale_factor, scale_factor)
 	translation += _direction * delta * _SPEED

--- a/GUI/DamageNumber/DamageNumber.gd
+++ b/GUI/DamageNumber/DamageNumber.gd
@@ -1,7 +1,10 @@
 extends Sprite3D
 
-const _LIFETIME := 0.75
-const _SPEED := 5
+const _LIFETIME := 1.25
+const _APPEAR_DURATION := 0.1
+const _DISAPPEAR_DURATION := 0.25
+const _SPEED := 3.0
+const SPAWN_OFFSET_RANGE := 1.0
 
 var _damage: int
 var _effectiveness: float
@@ -37,17 +40,18 @@ func _physics_process(delta: float) -> void:
 		_update(delta)
 
 func _update(delta: float) -> void:
-	var progress = _total_delta / _LIFETIME
 	var pos = get_global_transform().origin
 	var cam = get_tree().get_root().get_camera()
 	var screen_pos = cam.unproject_position(pos)
 	var position = screen_pos - Vector2(_label.rect_size.x * 0.5, _label.rect_size.y * 0.75)
 	
-	var progress_scale_factor = 1.0 - progress / 2
-	var effectiveness_scale_factor = 0.5 + 0.5 * _effectiveness
-	var scale_factor = progress_scale_factor * effectiveness_scale_factor
+	var time_scale_factor = clamp(_total_delta / _APPEAR_DURATION, 0, 1)
+	var effectiveness_scale_factor = 0.5 + 0.5 * pow(_effectiveness, 2)
+	var scale_factor = time_scale_factor * effectiveness_scale_factor
 	
+	var time_left = _LIFETIME - _total_delta
+	var opacity = clamp(time_left / _DISAPPEAR_DURATION, 0, 1)
 	_label.set_position(position)
-	_label.modulate.a = 1.0 - progress
+	_label.modulate.a = opacity
 	_label.rect_scale = Vector2(scale_factor, scale_factor)
 	translation += _direction * delta * _SPEED

--- a/GUI/DamageNumber/DamageNumber.gd
+++ b/GUI/DamageNumber/DamageNumber.gd
@@ -1,0 +1,43 @@
+extends Sprite3D
+
+const _LIFETIME := 1.0
+const _SPEED := 5
+
+var _damage: int
+var _direction = Vector3(1, 0, 1)
+var _total_delta: float = 0
+var _color: Color
+
+onready var _label = $Label
+
+func _ready() -> void:
+	var entity = get_parent()
+
+func set_damage(damage: int):
+	_damage = damage
+	$Label.text = str(damage)
+
+func set_damage_effectiveness(effectiveness: float) -> void:
+	if effectiveness < 0.5:
+		_color = Color.green
+	elif effectiveness < 0.75:
+		_color = Color.orange
+	else:
+		_color = Color.red
+	$Label.modulate = _color
+
+func _physics_process(delta: float) -> void:
+	_total_delta += delta
+	if _total_delta > _LIFETIME:
+		queue_free()
+	else:
+		var progress = _total_delta / _LIFETIME
+		var pos = get_global_transform().origin
+		var cam = get_tree().get_root().get_camera()
+		var screen_pos = cam.unproject_position(pos)
+		var size = _label.get_size()
+		var scale = _label.get_scale()
+		var position = screen_pos + Vector2(0, -size.y * scale.y)
+		_label.set_position(position)
+		_label.modulate.a = 1.0 - progress
+		translation += _direction * delta * _SPEED

--- a/GUI/DamageNumber/DamageNumber.tscn
+++ b/GUI/DamageNumber/DamageNumber.tscn
@@ -12,6 +12,8 @@ margin_right = 157.228
 margin_bottom = 57.0
 custom_fonts/font = ExtResource( 2 )
 text = "some text"
+align = 1
+valign = 1
 __meta__ = {
 "_edit_use_anchors_": false
 }

--- a/GUI/DamageNumber/DamageNumber.tscn
+++ b/GUI/DamageNumber/DamageNumber.tscn
@@ -1,0 +1,17 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://GUI/DamageNumber/DamageNumber.gd" type="Script" id=1]
+[ext_resource path="res://Fonts/DamageNumber.tres" type="DynamicFont" id=2]
+
+[node name="DamageNumber" type="Sprite3D"]
+script = ExtResource( 1 )
+
+[node name="Label" type="Label" parent="."]
+margin_left = 1.22778
+margin_right = 157.228
+margin_bottom = 57.0
+custom_fonts/font = ExtResource( 2 )
+text = "some text"
+__meta__ = {
+"_edit_use_anchors_": false
+}

--- a/GUI/EnemyHealthBar/HealthBar.tscn
+++ b/GUI/EnemyHealthBar/HealthBar.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://GUI/PlayerHealthBar/healthbarback.png" type="Texture" id=1]
+[ext_resource path="res://GUI/PlayerHealthBar/healthbarfront.png" type="Texture" id=2]
+[ext_resource path="res://Enemy/HealthBar.gd" type="Script" id=3]
+
+[sub_resource type="SpatialMaterial" id=1]
+flags_transparent = true
+flags_unshaded = true
+params_billboard_mode = 1
+
+[node name="HealthBar" type="Sprite3D"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.62991, 0 )
+material_override = SubResource( 1 )
+script = ExtResource( 3 )
+
+[node name="ProgressBar" type="TextureProgress" parent="."]
+margin_right = 536.0
+margin_bottom = 77.0
+rect_scale = Vector2( 0.1, 0.1 )
+texture_under = ExtResource( 1 )
+texture_progress = ExtResource( 2 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="Tween" type="Tween" parent="."]

--- a/GUI/GUI.tscn
+++ b/GUI/GUI.tscn
@@ -124,17 +124,17 @@ __meta__ = {
 [node name="Tween" type="Tween" parent="LevelGUI/MarginContainer/VBoxContainer/PlayerHealthBarContainer/PlayerHealthBar"]
 
 [node name="CenterContainer" type="CenterContainer" parent="LevelGUI/MarginContainer/VBoxContainer/PlayerHealthBarContainer"]
-margin_left = 268.0
-margin_top = 37.0
-margin_right = 274.0
-margin_bottom = 39.0
+margin_left = 242.0
+margin_top = 18.0
+margin_right = 301.0
+margin_bottom = 59.0
 __meta__ = {
 "_edit_use_anchors_": false
 }
 
 [node name="HealthPoints" type="Label" parent="LevelGUI/MarginContainer/VBoxContainer/PlayerHealthBarContainer/CenterContainer"]
-margin_right = 6.0
-margin_bottom = 2.0
+margin_right = 59.0
+margin_bottom = 41.0
 custom_fonts/font = ExtResource( 4 )
 text = "50/100"
 __meta__ = {

--- a/LevelManager/LevelManager.tscn
+++ b/LevelManager/LevelManager.tscn
@@ -9,9 +9,6 @@
 [ext_resource path="res://GUI/GUI.tscn" type="PackedScene" id=8]
 [ext_resource path="res://GUI/Joystick/knob.png" type="Texture" id=9]
 
-
-
-
 [sub_resource type="CircleShape2D" id=1]
 
 [node name="LevelManager" type="Spatial"]


### PR DESCRIPTION
Bullets now also have a `mean_damage` and `spread` to specify bullet damage range.

### Damage numbers
The damage numbers make use of an `effectiveness` float passed in by the projectile/damage-causing object. The float will be in the range 0 to 1, inclusive, with 0 being the least effective and 1 being the most effective. This float will then determine the colour of the damage number for that projectile.