### PR TITLE
Add crit and screenshake

### DIFF
--- a/Camera/Camera.gd
+++ b/Camera/Camera.gd
@@ -1,28 +1,56 @@
 extends Camera
 
 onready var _player: Player = get_tree().get_root().find_node("LevelManager", true, false).find_node("Player")
+
 var _initialized := false
 var _velocity: Vector3
+var _actual_position: Vector3
+var _trauma := 0.0
+
 const _BASE_ACCELERATION = 80
 const _FRICTION = 0.9
 const _CAMERA_HEIGHT = 25
 const _THRESHOLD_DISTANCE = 2 # Maximum distance from the player at which the camera won't move
 
+const _MAX_TRAUMA = 1.1;
+const _TRAUMA_FALL = 0.1;
+const _ROTATION_SHAKE_SCALE = 1.2
+const _X_SHAKE_SCALE = 1.2
+const _Z_SHAKE_SCALE = 1.2
+const _Y_ROTATION_BASE = -90
+
 func _physics_process(delta: float) -> void:
 	if not _initialized:
 		var player_origin := _player.transform.origin
-		transform.origin = Vector3(player_origin.x, player_origin.y + _CAMERA_HEIGHT * 1.5,  player_origin.z) # Animate camera down from above
+		_actual_position = Vector3(player_origin.x, player_origin.y + _CAMERA_HEIGHT * 1.5,  player_origin.z) # Animate camera down from above
+		transform.origin = _actual_position
 		_initialized = true
 		return
 
 	var player_origin := _player.transform.origin
 	var target_origin = Vector3(player_origin.x, player_origin.y + _CAMERA_HEIGHT, player_origin.z)
-	var direction = transform.origin.direction_to(target_origin)
-	var distance_to_player = transform.origin.distance_to(target_origin) - _THRESHOLD_DISTANCE
+	var direction = _actual_position.direction_to(target_origin)
+	var distance_to_player = _actual_position.distance_to(target_origin) - _THRESHOLD_DISTANCE
 	distance_to_player = max(distance_to_player, 0)
 
 	var acceleration = _BASE_ACCELERATION * distance_to_player * direction
 
 	_velocity += acceleration * delta
 	_velocity *= _FRICTION
-	transform.origin += _velocity * delta
+	_actual_position += _velocity * delta
+
+	_screenshake()
+
+func _screenshake() -> void:
+	var shake := pow(_trauma, 2)
+	var x := _actual_position.x
+	var z := _actual_position.z
+	transform.origin = _actual_position
+	transform.origin.x += _X_SHAKE_SCALE * shake * (randf() * 2 - 1)
+	transform.origin.z += _Z_SHAKE_SCALE * shake * (randf() * 2 - 1)
+	rotation_degrees.y = _Y_ROTATION_BASE + _ROTATION_SHAKE_SCALE * shake * (randf() * 2 - 1)
+
+	_trauma = max(0, _trauma - _TRAUMA_FALL)
+
+func apply_damage_trauma(trauma: float) -> void:
+	_trauma = min(max(_trauma, trauma), _MAX_TRAUMA)

--- a/Camera/Camera.gd
+++ b/Camera/Camera.gd
@@ -6,18 +6,25 @@ var _initialized := false
 var _velocity: Vector3
 var _actual_position: Vector3
 var _trauma := 0.0
+var _shake_delta := 0.0
 
 const _BASE_ACCELERATION = 80
 const _FRICTION = 0.9
 const _CAMERA_HEIGHT = 25
 const _THRESHOLD_DISTANCE = 2 # Maximum distance from the player at which the camera won't move
 
-const _MAX_TRAUMA = 1.1;
-const _TRAUMA_FALL = 0.1;
-const _ROTATION_SHAKE_SCALE = 1.2
-const _X_SHAKE_SCALE = 1.2
-const _Z_SHAKE_SCALE = 1.2
+const _MAX_TRAUMA = 1;
+const _TRAUMA_FALL = 0.05;
+const _ROTATION_SHAKE_SCALE = 5
+const _X_SHAKE_SCALE = 1
+const _Z_SHAKE_SCALE = 1
 const _Y_ROTATION_BASE = -90
+const _NOISE_PERIOD = 0.5
+
+onready var noise := OpenSimplexNoise.new()
+
+func _ready() -> void:
+	noise.set_period(_NOISE_PERIOD)
 
 func _physics_process(delta: float) -> void:
 	if not _initialized:
@@ -39,18 +46,21 @@ func _physics_process(delta: float) -> void:
 	_velocity *= _FRICTION
 	_actual_position += _velocity * delta
 
-	_screenshake()
+	_screen_shake_process(delta)
 
-func _screenshake() -> void:
+func _screen_shake_process(delta: float) -> void:
+	_trauma = clamp(_trauma - _TRAUMA_FALL, 0, _MAX_TRAUMA)
 	var shake := pow(_trauma, 2)
 	var x := _actual_position.x
 	var z := _actual_position.z
 	transform.origin = _actual_position
-	transform.origin.x += _X_SHAKE_SCALE * shake * (randf() * 2 - 1)
-	transform.origin.z += _Z_SHAKE_SCALE * shake * (randf() * 2 - 1)
-	rotation_degrees.y = _Y_ROTATION_BASE + _ROTATION_SHAKE_SCALE * shake * (randf() * 2 - 1)
+	transform.origin.x += _X_SHAKE_SCALE * shake * noise.get_noise_2d(0, _shake_delta)
+	transform.origin.z += _Z_SHAKE_SCALE * shake * noise.get_noise_2d(1, _shake_delta)
+	rotation_degrees.y = _Y_ROTATION_BASE + _ROTATION_SHAKE_SCALE * shake * noise.get_noise_2d(2, _shake_delta)
 
-	_trauma = max(0, _trauma - _TRAUMA_FALL)
+	_shake_delta += delta
+	if _trauma == 0:
+		_shake_delta = 0
 
-func apply_damage_trauma(trauma: float) -> void:
-	_trauma = min(max(_trauma, trauma), _MAX_TRAUMA)
+func apply_damage_trauma(effectiveness: float) -> void:
+	_trauma += effectiveness

--- a/GUI/DamageNumber/DamageNumber.gd
+++ b/GUI/DamageNumber/DamageNumber.gd
@@ -29,7 +29,8 @@ func set_damage_effectiveness(effectiveness: float) -> void:
 		_color = Color.orange
 	else:
 		_color = Color.red
-	_effectiveness = effectiveness
+
+	_effectiveness = min(effectiveness, 1.2)
 	$Label.modulate = _color
 
 func _physics_process(delta: float) -> void:

--- a/LevelManager/LevelManager.gd
+++ b/LevelManager/LevelManager.gd
@@ -115,3 +115,6 @@ func _on_animated_to_next_level() -> void:
 
 func on_loot_collected() -> void:
 	emit_signal("loot_collected")
+
+func on_bullet_damaged(effectiveness: float) -> void:
+	_camera.apply_damage_trauma(effectiveness)

--- a/LevelManager/LevelManager.tscn
+++ b/LevelManager/LevelManager.tscn
@@ -17,7 +17,7 @@ script = ExtResource( 2 )
 [node name="LevelPosition" type="Spatial" parent="."]
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( -3.89697e-08, 0.970972, -0.239194, 1.58191e-07, 0.239194, 0.970972, 1, 1.49214e-13, -1.6292e-07, -7.022, 25, -0.081 )
+transform = Transform( -1.16815e-07, 0.970972, -0.239194, 1.58191e-07, 0.239194, 0.970972, 1, 7.55854e-08, -1.8154e-07, -7.022, 25, -0.081 )
 fov = 96.0
 script = ExtResource( 1 )
 


### PR DESCRIPTION
Can playtest a bit and give some feedback

Idea for screenshake is
- Add a small offset to the x and z translation, and y rotation from its original position, based on a `_trauma` value 
- `_trauma` is updated two ways, 
  - reduced in every call of `physics_process` so that it falls back to 0
  - or update to the `effectiveness` value when bullet dealt damage