### PR TITLE
Basic room generator, enable player collision

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -54,8 +54,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Scripts\Generator\RoomGenerator.cs" />
     <Compile Include="Scripts\InputMode.cs" />
-    <Compile Include="Scripts\LevelGenerator.cs" />
     <Compile Include="Scripts\Player.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Tools</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{EA76A828-D999-44A5-9477-486A6B8A084D}</ProjectGuid>
+    <ProjectGuid>{EF469854-4FED-4991-B815-8FBC6046A04F}</ProjectGuid>
     <OutputType>Library</OutputType>
     <OutputPath>.mono/temp/bin/$(Configuration)</OutputPath>
     <RootNamespace>ComaDash</RootNamespace>
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Scripts\InputMode.cs" />
+    <Compile Include="Scripts\LevelGenerator.cs" />
     <Compile Include="Scripts\Player.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://Scripts/Player.cs" type="Script" id=1]
-[ext_resource path="res://Scripts/LevelGenerator.cs" type="Script" id=2]
+[ext_resource path="res://Scripts/Generator/RoomGenerator.cs" type="Script" id=2]
 
 [sub_resource type="CylinderMesh" id=1]
 
@@ -20,11 +20,11 @@ albedo_color = Color( 1, 1, 1, 0.501961 )
 [sub_resource type="SpatialMaterial" id=6]
 albedo_color = Color( 0.384314, 0.384314, 0.384314, 1 )
 
-[sub_resource type="CylinderShape" id=9]
+[sub_resource type="CylinderShape" id=7]
 
-[sub_resource type="CubeMesh" id=7]
+[sub_resource type="CubeMesh" id=8]
 
-[sub_resource type="BoxShape" id=8]
+[sub_resource type="BoxShape" id=9]
 
 [node name="Spatial" type="Spatial"]
 
@@ -53,19 +53,19 @@ mesh = SubResource( 5 )
 material = SubResource( 6 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Player"]
-shape = SubResource( 9 )
+shape = SubResource( 7 )
 
 [node name="Floor" type="StaticBody" parent="."]
 transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, 0, 0 )
 
 [node name="CSGMesh" type="CSGMesh" parent="Floor"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.901901, 0 )
-mesh = SubResource( 7 )
+mesh = SubResource( 8 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-shape = SubResource( 8 )
+shape = SubResource( 9 )
 
-[node name="LevelGenerator" type="Spatial" parent="."]
+[node name="RoomGenerator" type="Spatial" parent="."]
 script = ExtResource( 2 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -1,32 +1,35 @@
-[gd_scene load_steps=10 format=2]
+[gd_scene load_steps=12 format=2]
 
 [ext_resource path="res://Scripts/Player.cs" type="Script" id=1]
+[ext_resource path="res://Scripts/LevelGenerator.cs" type="Script" id=2]
 
 [sub_resource type="CylinderMesh" id=1]
 
-[sub_resource type="SpatialMaterial" id=3]
+[sub_resource type="SpatialMaterial" id=2]
 albedo_color = Color( 1, 0.0117647, 0.0117647, 1 )
 
-[sub_resource type="PrismMesh" id=4]
+[sub_resource type="PrismMesh" id=3]
 size = Vector3( 2, 7.39, 2 )
 
-[sub_resource type="SpatialMaterial" id=8]
+[sub_resource type="SpatialMaterial" id=4]
 flags_transparent = true
 albedo_color = Color( 1, 1, 1, 0.501961 )
 
 [sub_resource type="CylinderMesh" id=5]
 
-[sub_resource type="SpatialMaterial" id=7]
+[sub_resource type="SpatialMaterial" id=6]
 albedo_color = Color( 0.384314, 0.384314, 0.384314, 1 )
 
-[sub_resource type="CubeMesh" id=2]
+[sub_resource type="CylinderShape" id=9]
 
-[sub_resource type="BoxShape" id=6]
+[sub_resource type="CubeMesh" id=7]
+
+[sub_resource type="BoxShape" id=8]
 
 [node name="Spatial" type="Spatial"]
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, -1.62921e-07, 1, 0, -1, -1.62921e-07, 0, 18.1391, 0 )
+transform = Transform( 1, 0, 0, 0, 0.294958, 0.95551, 0, -0.95551, 0.294958, 0, 28.9074, 10.8886 )
 
 [node name="Player" type="KinematicBody" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0 )
@@ -34,27 +37,37 @@ script = ExtResource( 1 )
 
 [node name="CSGMesh" type="CSGMesh" parent="Player"]
 mesh = SubResource( 1 )
-material = SubResource( 3 )
+material = SubResource( 2 )
 
 [node name="Aiming" type="Spatial" parent="Player"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
 
 [node name="ArcIndicator" type="CSGMesh" parent="Player/Aiming"]
 transform = Transform( -1.00011, -1.27101e-07, 4.17653e-07, 1.62938e-07, 1.03537e-14, 2.56354, -3.25876e-07, 0.390071, 6.80443e-14, 0, 0.297, -1.40811 )
-mesh = SubResource( 4 )
-material = SubResource( 8 )
+mesh = SubResource( 3 )
+material = SubResource( 4 )
 
 [node name="RangeIndicator" type="CSGMesh" parent="Player/Aiming"]
 transform = Transform( 3, 0, 0, 0, 0.033, 0, 0, 0, 3, 0, 0, 0 )
 mesh = SubResource( 5 )
-material = SubResource( 7 )
+material = SubResource( 6 )
+
+[node name="CollisionShape" type="CollisionShape" parent="Player"]
+shape = SubResource( 9 )
 
 [node name="Floor" type="StaticBody" parent="."]
-transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, -2.02824, 0 )
+transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, 0, 0 )
 
 [node name="CSGMesh" type="CSGMesh" parent="Floor"]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.901901, 0 )
-mesh = SubResource( 2 )
+mesh = SubResource( 7 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-shape = SubResource( 6 )
+shape = SubResource( 8 )
+
+[node name="LevelGenerator" type="Spatial" parent="."]
+script = ExtResource( 2 )
+
+[node name="DirectionalLight" type="DirectionalLight" parent="."]
+transform = Transform( 0.618224, -0.112404, 0.777923, -0.784334, -0.152666, 0.601259, 0.0511787, -0.981865, -0.182544, 8.25041, 20.7953, -4.0208 )
+shadow_enabled = true

--- a/Scripts/Generator/RoomGenerator.cs
+++ b/Scripts/Generator/RoomGenerator.cs
@@ -2,7 +2,7 @@ using Godot;
 using System;
 using System.Diagnostics;
 
-public class LevelGenerator : Spatial
+public class RoomGenerator : Spatial
 {
     readonly SpatialMaterial wallMaterial = new SpatialMaterial
     {
@@ -46,7 +46,7 @@ public class LevelGenerator : Spatial
         Vector3 leftRightWallSize = new Vector3(roomSize.y - wallThickness, wallHeight, wallThickness);
         Vector3 left = Vector3.Up.Cross(front);
 
-        // Base of the wall is origin offset in the direction of the wall(i.e. front) by a length of half the size of the room - half the wall's thickness.
+        // Base of the wall is origin offset in the direction of the wall (i.e. front) by a length of half the size of the room - half the wall's thickness.
         // Also, we need to offset the wall's center to the side by half the wall's thickness.
         PhysicsBody frontWall = GenerateWall(origin + ((roomSize.y - wallThickness) / 2) * front + (wallThickness / 2) * left, frontBackWallSize, -front);
         PhysicsBody backWall = GenerateWall(origin - ((roomSize.y - wallThickness) / 2) * front - (wallThickness / 2) * left, frontBackWallSize, front);

--- a/Scripts/LevelGenerator.cs
+++ b/Scripts/LevelGenerator.cs
@@ -40,13 +40,13 @@ public class LevelGenerator : Spatial
          * BACK
          * 
          * So we subtract the wall thickness from the length of the wall, and offset the center
-         * of the wall by half the thickness.
+         * of the wall to the side by half the wall thickness.
          */
         Vector3 frontBackWallSize = new Vector3(roomSize.x - wallThickness, wallHeight, wallThickness);
         Vector3 leftRightWallSize = new Vector3(roomSize.y - wallThickness, wallHeight, wallThickness);
         Vector3 left = Vector3.Up.Cross(front);
 
-        // Base of the wall is origin + half the size of the room - half the wall's thickness.
+        // Base of the wall is origin offset in the direction of the wall(i.e. front) by a length of half the size of the room - half the wall's thickness.
         // Also, we need to offset the wall's center to the side by half the wall's thickness.
         PhysicsBody frontWall = GenerateWall(origin + ((roomSize.y - wallThickness) / 2) * front + (wallThickness / 2) * left, frontBackWallSize, -front);
         PhysicsBody backWall = GenerateWall(origin - ((roomSize.y - wallThickness) / 2) * front - (wallThickness / 2) * left, frontBackWallSize, front);
@@ -60,7 +60,7 @@ public class LevelGenerator : Spatial
     }
 
     /// <summary>
-    /// Returns a PhysicsBody representing a wall of a given size.
+    /// Returns a <c>PhysicsBody</c> representing a wall of a given size.
     /// </summary>
     /// <param name="wallBase">The center of the wall's base.</param>
     /// <param name="size">The length, height, and thickness of the wall.</param>

--- a/Scripts/LevelGenerator.cs
+++ b/Scripts/LevelGenerator.cs
@@ -15,7 +15,7 @@ public class LevelGenerator : Spatial
     {
         GenerateRoom(default, new Vector2(30, 20), Vector3.Forward);
     }
-    
+
     /// <summary>
     /// Generates a rectangular room of a given size.
     /// </summary>
@@ -80,9 +80,6 @@ public class LevelGenerator : Spatial
         CollisionShape collisionShape = new CollisionShape()
         {
             Shape = new BoxShape()
-            {
-                
-            }
         };
         wall.AddChild(meshInstance);
         wall.AddChild(collisionShape);

--- a/Scripts/LevelGenerator.cs
+++ b/Scripts/LevelGenerator.cs
@@ -1,0 +1,95 @@
+using Godot;
+using System;
+using System.Diagnostics;
+
+public class LevelGenerator : Spatial
+{
+    readonly SpatialMaterial wallMaterial = new SpatialMaterial
+    {
+        AlbedoColor = Colors.Gray
+    };
+    readonly float wallHeight = 4.0f;
+    readonly float wallThickness = 1.0f;
+
+    public override void _Ready()
+    {
+        GenerateRoom(default, new Vector2(30, 20), Vector3.Forward);
+    }
+    
+    /// <summary>
+    /// Generates a rectangular room of a given size.
+    /// </summary>
+    /// <param name="origin">The center of the base of the room.</param>
+    /// <param name="roomSize">The width and height of the room, inclusive of walls.</param>
+    /// <param name="front">The front direction the room is facing</param>
+    public void GenerateRoom(Vector3 origin, Vector2 roomSize, Vector3 front)
+    {
+        Debug.Assert(roomSize.Length() > 0, "Room size cannot be zero.");
+        Debug.Assert(wallThickness * 2 <= Math.Min(roomSize.x, roomSize.y), "Walls cannot be thicker than half the width/height of the room (there must be space within the room).");
+        front = front.Normalized();
+
+        /* We wish to generate walls in this manner:
+         *
+         * FRONT
+         * 
+         * aaab
+         * c  b
+         * c  b
+         * cddd
+         * 
+         * BACK
+         * 
+         * So we subtract the wall thickness from the length of the wall, and offset the center
+         * of the wall by half the thickness.
+         */
+        Vector3 frontBackWallSize = new Vector3(roomSize.x - wallThickness, wallHeight, wallThickness);
+        Vector3 leftRightWallSize = new Vector3(roomSize.y - wallThickness, wallHeight, wallThickness);
+        Vector3 left = Vector3.Up.Cross(front);
+
+        // Base of the wall is origin + half the size of the room - half the wall's thickness.
+        // Also, we need to offset the wall's center to the side by half the wall's thickness.
+        PhysicsBody frontWall = GenerateWall(origin + ((roomSize.y - wallThickness) / 2) * front + (wallThickness / 2) * left, frontBackWallSize, -front);
+        PhysicsBody backWall = GenerateWall(origin - ((roomSize.y - wallThickness) / 2) * front - (wallThickness / 2) * left, frontBackWallSize, front);
+        PhysicsBody leftWall = GenerateWall(origin + ((roomSize.x - wallThickness) / 2) * left - (wallThickness / 2) * front, leftRightWallSize, -left);
+        PhysicsBody rightWall = GenerateWall(origin - ((roomSize.x - wallThickness) / 2) * left + (wallThickness / 2) * front, leftRightWallSize, left);
+
+        AddChild(frontWall);
+        AddChild(backWall);
+        AddChild(leftWall);
+        AddChild(rightWall);
+    }
+
+    /// <summary>
+    /// Returns a PhysicsBody representing a wall of a given size.
+    /// </summary>
+    /// <param name="wallBase">The center of the wall's base.</param>
+    /// <param name="size">The length, height, and thickness of the wall.</param>
+    /// <param name="normal">The direction the wall's front is facing</param>
+    /// <returns></returns>
+    public PhysicsBody GenerateWall(Vector3 wallBase, Vector3 size, Vector3 normal)
+    {
+        Vector3 wallUp = Vector3.Up;
+        Mesh wallMesh = new CubeMesh();
+        MeshInstance meshInstance = new MeshInstance
+        {
+            Mesh = wallMesh
+        };
+        meshInstance.SetSurfaceMaterial(0, wallMaterial);
+
+        StaticBody wall = new StaticBody();
+        CollisionShape collisionShape = new CollisionShape()
+        {
+            Shape = new BoxShape()
+            {
+                
+            }
+        };
+        wall.AddChild(meshInstance);
+        wall.AddChild(collisionShape);
+
+        wall.Scale = size / 2;
+        wall.Translation = wallBase + size.y / 2 * wallUp;
+        wall.Rotation = new Vector3(0, 1, 0) * normal.AngleTo(Vector3.Forward);
+        return wall;
+    }
+}

--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -4,7 +4,7 @@ using Godot.Collections;
 
 public class Player : KinematicBody
 {
-    private const float Speed = 2000f;
+    private const float Speed = 20f;
     private const float DeadZone = 0.5f;
     private const float RotationSpeed = 30f;
 
@@ -20,7 +20,7 @@ public class Player : KinematicBody
 
     public void Move(Vector3 direction, float delta)
     {
-        this.MoveAndSlide(direction.Normalized() * Speed * delta);
+        this.MoveAndCollide(direction.Normalized() * Speed * delta);
     }
 
     public Vector2 CorrectJoystick(Vector2 rawInput, float deadZone)


### PR DESCRIPTION
Adds a LevelGenerator class which can generate a rectangular room of a given size, with four walls of a specified thickness and height.
![image](https://user-images.githubusercontent.com/8487294/80561802-42a24380-8a18-11ea-9821-67b85643e211.png)
