### PR TITLE
Add aim indicators

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -54,9 +54,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Scripts\AimIndicator\AimIndicator.cs" />
+    <Compile Include="Scripts\AimIndicator\ConicalAimIndicator.cs" />
+    <Compile Include="Scripts\AimIndicator\DetachedCircularAimIndicator.cs" />
+    <Compile Include="Scripts\AimIndicator\StraightAimIndicator.cs" />
     <Compile Include="Scripts\Generator\RoomGenerator.cs" />
     <Compile Include="Scripts\InputMode.cs" />
     <Compile Include="Scripts\Player.cs" />
+    <Compile Include="Scripts\Weapon.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -1,78 +1,62 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=13 format=2]
 
 [ext_resource path="res://Scripts/Player.cs" type="Script" id=1]
 [ext_resource path="res://Scripts/Generator/RoomGenerator.cs" type="Script" id=2]
+[ext_resource path="res://Scripts/AimIndicator/ConicalAimIndicator.cs" type="Script" id=3]
+[ext_resource path="res://Scripts/Weapon.cs" type="Script" id=4]
 
 [sub_resource type="CylinderMesh" id=1]
 
 [sub_resource type="SpatialMaterial" id=2]
 albedo_color = Color( 1, 0.0117647, 0.0117647, 1 )
 
-[sub_resource type="PrismMesh" id=3]
-size = Vector3( 2, 7.39, 2 )
+[sub_resource type="CylinderShape" id=3]
 
-[sub_resource type="SpatialMaterial" id=4]
-flags_transparent = true
-albedo_color = Color( 1, 1, 1, 0.501961 )
-
-[sub_resource type="CylinderMesh" id=5]
-
-[sub_resource type="SpatialMaterial" id=6]
-albedo_color = Color( 0.384314, 0.384314, 0.384314, 1 )
-
-[sub_resource type="CylinderShape" id=7]
-
-[sub_resource type="PlaneMesh" id=8]
+[sub_resource type="PlaneMesh" id=4]
 subdivide_width = 4
 
-[sub_resource type="BoxShape" id=9]
+[sub_resource type="BoxShape" id=5]
 
-[sub_resource type="SpatialMaterial" id=10]
+[sub_resource type="SpatialMaterial" id=6]
 albedo_color = Color( 0.878431, 0.313726, 0.313726, 1 )
 
-[sub_resource type="SpatialMaterial" id=11]
-albedo_color = Color( 0.764706, 0.47451, 0.137255, 1 )
+[sub_resource type="SpatialMaterial" id=7]
+albedo_color = Color( 0.765625, 0.476132, 0.137573, 1 )
 
-[sub_resource type="SpatialMaterial" id=12]
+[sub_resource type="SpatialMaterial" id=8]
 albedo_color = Color( 0.12549, 0.0823529, 0.00784314, 1 )
 
 [node name="Spatial" type="Spatial"]
 
 [node name="Camera" type="Camera" parent="."]
-transform = Transform( 1, 0, 0, 0, 0.294958, 0.95551, 0, -0.95551, 0.294958, 0, 39.6402, 10.8886 )
+transform = Transform( 1, 0, 0, 0, 0.273624, 0.961837, 0, -0.961837, 0.273624, 0, 41.1317, 16.6626 )
 
 [node name="Player" type="KinematicBody" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.5, 0 )
 script = ExtResource( 1 )
 
 [node name="CSGMesh" type="CSGMesh" parent="Player"]
 mesh = SubResource( 1 )
 material = SubResource( 2 )
 
-[node name="Aiming" type="Spatial" parent="Player"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
-
-[node name="ArcIndicator" type="CSGMesh" parent="Player/Aiming"]
-transform = Transform( -1.00011, -1.27101e-07, 4.17653e-07, 1.62938e-07, 1.03537e-14, 2.56354, -3.25876e-07, 0.390071, 6.80443e-14, 0, 0.297, -1.40811 )
-mesh = SubResource( 3 )
-material = SubResource( 4 )
-
-[node name="RangeIndicator" type="CSGMesh" parent="Player/Aiming"]
-transform = Transform( 3, 0, 0, 0, 0.033, 0, 0, 0, 3, 0, 0, 0 )
-mesh = SubResource( 5 )
-material = SubResource( 6 )
-
 [node name="CollisionShape" type="CollisionShape" parent="Player"]
-shape = SubResource( 7 )
+shape = SubResource( 3 )
+
+[node name="Weapon" type="Spatial" parent="Player"]
+script = ExtResource( 4 )
+
+[node name="AimIndicator" type="Spatial" parent="Player/Weapon"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
+script = ExtResource( 3 )
 
 [node name="Floor" type="StaticBody" parent="."]
 transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, -2, 0 )
 
 [node name="CSGMesh" type="CSGMesh" parent="Floor"]
-mesh = SubResource( 8 )
+mesh = SubResource( 4 )
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-shape = SubResource( 9 )
+shape = SubResource( 5 )
 
 [node name="RoomGenerator" type="Spatial" parent="."]
 script = ExtResource( 2 )
@@ -81,9 +65,9 @@ WallThickness = 2.0
 TileSize = Vector3( 2, 0.2, 5 )
 TileOffset = 0.5
 TileSpacing = 0.25
-WallMaterial = SubResource( 10 )
-TileMaterial = SubResource( 11 )
-GroutMaterial = SubResource( 12 )
+WallMaterial = SubResource( 6 )
+TileMaterial = SubResource( 7 )
+GroutMaterial = SubResource( 8 )
 
 [node name="DirectionalLight" type="DirectionalLight" parent="."]
 transform = Transform( 0.618224, -0.112404, 0.777923, -0.784334, -0.152666, 0.601259, 0.0511787, -0.981865, -0.182544, 8.25041, 20.7953, -4.0208 )

--- a/Scripts/AimIndicator/AimIndicator.cs
+++ b/Scripts/AimIndicator/AimIndicator.cs
@@ -1,0 +1,106 @@
+using System;
+using Godot;
+
+/// <summary>
+/// <para>
+/// A <see cref="Spatial"/> that displays a mesh representing the trajectory of a <see cref="Weapon"/>.
+/// The mesh is positioned such that it rests on, and is projected outward from the origin of the <see cref="AimIndicator"/>.
+/// </para>
+/// 
+/// The following classes implement this class
+/// <seealso cref="ConicalAimIndicator"/>,
+/// <seealso cref="DetachedCircularAimIndicator"/>,
+/// <seealso cref="StraightAimIndicator"/>
+/// </summary>
+public abstract class AimIndicator : Spatial
+{
+    public float Range
+    {
+        get
+        {
+            return range;
+        }
+        set
+        {
+            range = value;
+            RebuildIndicator();
+        }
+    }
+
+    [Export]
+    public float Height
+    {
+        get
+        {
+            return height;
+        }
+        set
+        {
+            height = value;
+            RebuildIndicator();
+        }
+    }
+
+    [Export]
+    public Material Material
+    {
+        get
+        {
+            return material;
+        }
+        set
+        {
+            material = value;
+            RebuildIndicator();
+        }
+    }
+
+    public Vector2 JoyAxis
+    {
+        set
+        {
+            UpdateTransform(value);
+            UpdateIndicatorTransform(value);
+        }
+    }
+
+    protected float range = 10.0f;
+    protected float height = 0.1f;
+    protected Material material = new SpatialMaterial()
+    {
+        AlbedoColor = new Color(1, 1, 1, 0.5f),
+        FlagsTransparent = true
+    };
+    protected Spatial indicator;
+
+    public override void _Ready()
+    {
+        BuildIndicator();
+        AddChild(indicator);
+    }
+
+    protected abstract void BuildIndicator();
+
+    protected void RebuildIndicator()
+    {
+        indicator?.QueueFree();
+        BuildIndicator();
+        AddChild(indicator);
+    }
+
+    private void UpdateTransform(Vector2 correctedJoyAxis)
+    {
+        if (correctedJoyAxis.Length() == 0)
+            indicator.Hide();
+        else
+            indicator.Show();
+
+        float attackAngleDegrees = (float)(new Vector2(correctedJoyAxis.x, -correctedJoyAxis.y).Angle() * 180 / Math.PI);
+        RotationDegrees = new Vector3(0, attackAngleDegrees, 0);
+    }
+
+    protected virtual void UpdateIndicatorTransform(Vector2 correctedJoyAxis)
+    {
+
+    }
+}

--- a/Scripts/AimIndicator/ConicalAimIndicator.cs
+++ b/Scripts/AimIndicator/ConicalAimIndicator.cs
@@ -1,0 +1,43 @@
+using Godot;
+
+/// <summary>
+/// <para>
+/// An <see cref="AimIndicator"/> that displays a conical shaped indicator of a given angle that originates from the player.
+/// </para>
+/// <para>
+/// This is used for melee weapons or weapons that have a conical trajectory.
+/// </para>
+/// </summary>
+
+public class ConicalAimIndicator : AimIndicator
+{
+    [Export(PropertyHint.Range, "0, 360")]
+    public float SpreadDegrees
+    {
+        get
+        {
+            return spreadDegrees;
+        }
+        set
+        {
+            spreadDegrees = value;
+            RebuildIndicator();
+        }
+    }
+
+    protected float spreadDegrees = 90.0f;
+
+    protected override void BuildIndicator()
+    {
+        indicator = new CSGPolygon
+        {
+            Polygon = new Vector2[] { Vector2.Zero, new Vector2(0, height), new Vector2(range, height), new Vector2(range, 0) },
+            Mode = CSGPolygon.ModeEnum.Spin,
+            SpinDegrees = spreadDegrees,
+            SpinSides = (int)(spreadDegrees / 5),
+            RotationDegrees = new Vector3(0, -spreadDegrees / 2, 0),
+            Translation = new Vector3(0, height / 2, 0),
+            Material = material
+        };
+    }
+}

--- a/Scripts/AimIndicator/DetachedCircularAimIndicator.cs
+++ b/Scripts/AimIndicator/DetachedCircularAimIndicator.cs
@@ -1,0 +1,50 @@
+using Godot;
+
+/// <summary>
+/// <para>
+/// An <see cref="AimIndicator"/> that displays a circle that is not centred on the player.
+/// </para>
+/// 
+/// <para>
+/// This is used for area-of-effect weapons that could be thrown away from the player.
+/// As such. its position is determined by how far the player aims the projectile.
+/// </para>
+/// </summary>
+public class DetachedCircularAimIndicator : AimIndicator
+{
+    [Export]
+    public float Radius
+    {
+        get
+        {
+            return radius;
+        }
+        set
+        {
+            radius = value;
+            RebuildIndicator();
+        }
+    }
+
+    private float radius = 2.5f;
+
+    protected override void BuildIndicator()
+    {
+        indicator = new CSGCylinder
+        {
+            Radius = radius,
+            Height = height,
+            Sides = 16,
+            SmoothFaces = true,
+            Translation = new Vector3(0, height / 2, 0),
+            Material = material
+        };
+    }
+
+    protected override void UpdateIndicatorTransform(Vector2 correctedJoyAxis)
+    {
+        GD.Print(correctedJoyAxis);
+        GD.Print(correctedJoyAxis.Length());
+        indicator.Translation = new Vector3(correctedJoyAxis.Length() * range, height / 2, 0);
+    }
+}

--- a/Scripts/AimIndicator/DetachedCircularAimIndicator.cs
+++ b/Scripts/AimIndicator/DetachedCircularAimIndicator.cs
@@ -43,8 +43,6 @@ public class DetachedCircularAimIndicator : AimIndicator
 
     protected override void UpdateIndicatorTransform(Vector2 correctedJoyAxis)
     {
-        GD.Print(correctedJoyAxis);
-        GD.Print(correctedJoyAxis.Length());
         indicator.Translation = new Vector3(correctedJoyAxis.Length() * range, height / 2, 0);
     }
 }

--- a/Scripts/AimIndicator/StraightAimIndicator.cs
+++ b/Scripts/AimIndicator/StraightAimIndicator.cs
@@ -1,0 +1,41 @@
+using Godot;
+
+/// <summary>
+/// <para>
+/// An <see cref="AimIndicator"/> that displays a straight line of a given width that originates from the player
+/// </para>
+/// <para>
+/// This is used for weapons with straight trajectories.
+/// </para>
+/// </summary>
+public class StraightAimIndicator : AimIndicator
+{
+    [Export]
+    public float Width
+    {
+        get
+        {
+            return width;
+        }
+        set
+        {
+            width = value;
+            RebuildIndicator();
+        }
+    }
+
+    protected float width = 2.0f;
+
+    protected override void BuildIndicator()
+    {
+        indicator = new CSGBox
+        {
+            Width = width,
+            Height = height,
+            Depth = range,
+            Material = material,
+            Translation = new Vector3(range / 2, height, 0),
+            RotationDegrees = new Vector3(0, 90, 0)
+        };
+    }
+}

--- a/Scripts/Generator/RoomGenerator.cs
+++ b/Scripts/Generator/RoomGenerator.cs
@@ -224,7 +224,7 @@ public class RoomGenerator : Spatial
         meshInstance.SetSurfaceMaterial(0, wallMaterial);
 
         StaticBody wall = new StaticBody();
-        CollisionShape collisionShape = new CollisionShape()
+        CollisionShape collisionShape = new CollisionShape
         {
             Shape = new BoxShape()
         };
@@ -281,11 +281,11 @@ public class RoomGenerator : Spatial
                     currentTileSize.x -= extraWidth;
                 }
 
-                Mesh tileMesh = new CubeMesh()
+                Mesh tileMesh = new CubeMesh
                 {
                     Size = currentTileSize
                 };
-                MeshInstance meshInstance = new MeshInstance()
+                MeshInstance meshInstance = new MeshInstance
                 {
                     Mesh = tileMesh
                 };
@@ -306,11 +306,11 @@ public class RoomGenerator : Spatial
     public void GenerateGrout()
     {
         floor.GetNodeOrNull<MeshInstance>("Grout")?.QueueFree();
-        Mesh groutMesh = new PlaneMesh()
+        Mesh groutMesh = new PlaneMesh
         {
             Size = RoomSpaceSize
         };
-        MeshInstance meshInstance = new MeshInstance()
+        MeshInstance meshInstance = new MeshInstance
         {
             Mesh = groutMesh
         };

--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -5,17 +5,17 @@ using Godot.Collections;
 public class Player : KinematicBody
 {
     private const float Speed = 20f;
-    private const float DeadZone = 0.5f;
     private const float RotationSpeed = 30f;
-
     private Vector2 mousePosition;
     private Camera camera;
     private InputMode inputMode = InputMode.Keyboard;
     private Vector3 previousFaceDirection = Vector3.Forward;
+    private Weapon weapon;
 
     public override void _Ready()
     {
         camera = GetParent().GetNode<Camera>("Camera");
+        weapon = GetNode<Weapon>("Weapon");
     }
 
     public void Move(Vector3 direction, float delta)
@@ -25,8 +25,7 @@ public class Player : KinematicBody
 
     public Vector2 CorrectJoystick(Vector2 rawInput, float deadZone)
     {
-        return
-        rawInput.Length() > deadZone ? rawInput : default;
+        return rawInput.Length() > deadZone ? rawInput : default;
     }
 
     public override void _Input(InputEvent @event)
@@ -48,42 +47,19 @@ public class Player : KinematicBody
         Vector3 newFaceDirection = previousFaceDirection.Rotated(GetFaceDirection().Cross(previousFaceDirection), -angle);
         LookAt(Translation + newFaceDirection, Vector3.Up);
         previousFaceDirection = newFaceDirection.Normalized();
+
+        // So that the global rotation of the weapon will be zero
+        weapon.Rotation = -Rotation;
+        weapon.AttackDirection = GetAttackDirection();
     }
 
     private Vector3 GetMovementDirection()
     {
         Vector3 direction = default;
-        if (Input.IsActionPressed("movement_up"))
-        {
-            direction += Vector3.Forward;
-        }
-
-        if (Input.IsActionPressed("movement_down"))
-        {
-            direction += Vector3.Back;
-        }
-
-        if (Input.IsActionPressed("movement_left"))
-        {
-            direction += Vector3.Left;
-        }
-
-        if (Input.IsActionPressed("movement_right"))
-        {
-            direction += Vector3.Right;
-        }
-
-        if (Input.GetConnectedJoypads().Count > 0)
-        {
-            Vector2 rawJoystickInput = new Vector2(Input.GetJoyAxis(0, 0), Input.GetJoyAxis(0, 1));
-            Vector2 joystick = CorrectJoystick(rawJoystickInput, DeadZone);
-            if (joystick.Length() > 0)
-            {
-                inputMode = InputMode.Controller;
-            }
-
-            direction += ((Vector3.Right * joystick.x) + (Vector3.Back * joystick.y)).Normalized();
-        }
+        direction += (Vector3.Forward * Input.GetActionStrength("movement_up")).Normalized();
+        direction += (Vector3.Back * Input.GetActionStrength("movement_down")).Normalized();
+        direction += (Vector3.Left * Input.GetActionStrength("movement_left")).Normalized();
+        direction += (Vector3.Right * Input.GetActionStrength("movement_right")).Normalized();
 
         return direction;
     }
@@ -94,30 +70,73 @@ public class Player : KinematicBody
 
         if (Input.GetConnectedJoypads().Count > 0)
         {
-            Vector2 rawJoystickInput = new Vector2(Input.GetJoyAxis(0, 2), Input.GetJoyAxis(0, 3));
-            Vector2 joystick = CorrectJoystick(rawJoystickInput, DeadZone);
+            float horizontal = Input.GetActionStrength("aim_right") - Input.GetActionStrength("aim_left");
+            float vertical = Input.GetActionStrength("aim_down") - Input.GetActionStrength("aim_up");
+            Vector2 joystick = new Vector2(horizontal, vertical).Clamped(1.0f);
             if (joystick.Length() > 0)
             {
                 inputMode = InputMode.Controller;
             }
-
             direction += ((Vector3.Right * joystick.x) + (Vector3.Back * joystick.y)).Normalized();
         }
 
         if (inputMode == InputMode.Keyboard)
         {
-            Vector3 cameraRayOrigin = camera.ProjectRayOrigin(mousePosition);
-            Vector3 cameraRayTarget = cameraRayOrigin + (camera.ProjectRayNormal(mousePosition) * 1000);
-            Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(cameraRayOrigin, cameraRayTarget, null);
-            if (ray.Count > 0)
+            Vector3? cursorPosition = GetCursorPointOnPlayerPlane();
+            if (cursorPosition.HasValue)
             {
-                Vector3 cursorPointOnFloor = (Vector3)ray["position"];
-                cursorPointOnFloor.y = GlobalTransform.origin.y;
-
-                direction = cursorPointOnFloor - Translation;
+                direction = cursorPosition.Value - Translation;
             }
         }
 
         return direction.Normalized();
+    }
+
+    public Vector2 GetAttackDirection()
+    {
+        if (Input.GetConnectedJoypads().Count > 0)
+        {
+            float horizontal = Input.GetActionStrength("aim_right") - Input.GetActionStrength("aim_left");
+            float vertical = Input.GetActionStrength("aim_down") - Input.GetActionStrength("aim_up");
+            Vector2 joystick = new Vector2(horizontal, vertical).Clamped(1.0f);
+            if (joystick.Length() > 0)
+            {
+                inputMode = InputMode.Controller;
+                return joystick;
+            }
+        }
+
+        if (inputMode == InputMode.Keyboard)
+        {
+            Vector3? cursorPosition = GetCursorPointOnPlayerPlane();
+            if (cursorPosition.HasValue)
+            {
+                Vector3 displacement = cursorPosition.Value - Translation;
+                return weapon.GetAttackJoyAxisFromMouseDisplacement(displacement);
+            }
+        }
+
+        return Vector2.Zero;
+    }
+
+
+    /// <summary>
+    /// Returns the point above the floor that the cursor is pointing at, which is at the same height as the origin of the player.
+    /// Can be used to make the player face the cursor.
+    /// </summary>
+    /// <returns>The cursor point on the same plane as the player.</returns>
+    private Vector3? GetCursorPointOnPlayerPlane()
+    {
+        Vector3 cameraRayOrigin = camera.ProjectRayOrigin(mousePosition);
+        Vector3 cameraRayTarget = cameraRayOrigin + (camera.ProjectRayNormal(mousePosition) * 1000);
+        Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(cameraRayOrigin, cameraRayTarget, null);
+        if (ray.Count > 0)
+        {
+            Vector3 cursorPointOnFloor = (Vector3)ray["position"];
+            cursorPointOnFloor.y = GlobalTransform.origin.y;
+
+            return cursorPointOnFloor;
+        }
+        return null;
     }
 }

--- a/Scripts/Weapon.cs
+++ b/Scripts/Weapon.cs
@@ -1,0 +1,43 @@
+using Godot;
+
+public class Weapon : Spatial
+{
+    public Vector2 AttackDirection
+    {
+        set
+        {
+            AimIndicator.JoyAxis = value;
+        }
+    }
+
+    [Export]
+    public float Range
+    {
+        get
+        {
+            return range;
+        }
+        set
+        {
+            range = value;
+            if (AimIndicator != null)
+                AimIndicator.Range = value;
+        }
+    }
+
+    public AimIndicator AimIndicator;
+    private float range = 10.0f;
+
+    public override void _Ready()
+    {
+        AimIndicator = GetNode<AimIndicator>("AimIndicator");
+        AimIndicator.Range = range;
+    }
+
+    public Vector2 GetAttackJoyAxisFromMouseDisplacement(Vector3 mouseDisplacement)
+    {
+        Vector2 mouseDisplacement2D = new Vector2(mouseDisplacement.x, mouseDisplacement.z);
+        mouseDisplacement2D = (mouseDisplacement2D / range).Clamped(1.0f);
+        return mouseDisplacement2D;
+    }
+}

--- a/project.godot
+++ b/project.godot
@@ -30,23 +30,47 @@ ui_accept={
  ]
 }
 movement_down={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":1.0,"script":null)
  ]
 }
 movement_up={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":87,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":1,"axis_value":-1.0,"script":null)
  ]
 }
 movement_left={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":65,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":-1.0,"script":null)
  ]
 }
 movement_right={
-"deadzone": 0.5,
+"deadzone": 0.2,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":68,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":0,"axis_value":1.0,"script":null)
+ ]
+}
+aim_up={
+"deadzone": 0.2,
+"events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":3,"axis_value":-1.0,"script":null)
+ ]
+}
+aim_down={
+"deadzone": 0.2,
+"events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":3,"axis_value":1.0,"script":null)
+ ]
+}
+aim_left={
+"deadzone": 0.2,
+"events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":2,"axis_value":-1.0,"script":null)
+ ]
+}
+aim_right={
+"deadzone": 0.2,
+"events": [ Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":0,"axis":2,"axis_value":1.0,"script":null)
  ]
 }
 


### PR DESCRIPTION
Adds a conical, straight and detached circular (for thrown AOE weapons) aim indicator. Player now has a child Weapon node which describes the range of the weapon as well as its type of aim indicator.

The joystick mappings are also reworked to use `GetActionStrength` instead of manually listening for the joypad axes.
![image](https://user-images.githubusercontent.com/8487294/80698782-87f46d00-8b0d-11ea-9e8a-4132423a75f5.png)
![image](https://user-images.githubusercontent.com/8487294/80698843-9b9fd380-8b0d-11ea-8f19-3accb84ecc8f.png)
![image](https://user-images.githubusercontent.com/8487294/80698882-ac504980-8b0d-11ea-9852-d1a6df5d5555.png)
