### PR TITLE
Camera: Follow player and zoom on dash

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Scripts\Generator\Wall.cs" />
     <Compile Include="Scripts\InputMode.cs" />
     <Compile Include="Scripts\Player.cs" />
+    <Compile Include="Scripts\PlayerCamera.cs" />
     <Compile Include="Scripts\Projectile.cs" />
     <Compile Include="Scripts\Status\MarkStatus.cs" />
     <Compile Include="Scripts\Status\Status.cs" />

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -49,7 +49,7 @@ shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
 
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.461393, 0.887196, 0, -0.887196, 0.461393, 1.34645, 50.4642, 26.7106 )
-fov = 36.6
+fov = 35.0
 script = ExtResource( 2 )
 
 [node name="Player" type="KinematicBody" parent="."]

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=13 format=2]
+[gd_scene load_steps=14 format=2]
 
 [ext_resource path="res://Scripts/Player.cs" type="Script" id=1]
+[ext_resource path="res://Scripts/PlayerCamera.cs" type="Script" id=2]
 [ext_resource path="res://Scripts/AimIndicator/GeneralAimIndicator.cs" type="Script" id=3]
 [ext_resource path="res://Scripts/Weapon/OverheatingGun.cs" type="Script" id=4]
 [ext_resource path="res://Scenes/Enemy.tscn" type="PackedScene" id=5]
@@ -11,12 +12,12 @@
 
 [sub_resource type="BoxShape" id=2]
 
-[sub_resource type="StyleBoxFlat" id=6]
+[sub_resource type="StyleBoxFlat" id=3]
 bg_color = Color( 0.854902, 0.431373, 0.0941176, 1 )
 
-[sub_resource type="SpatialMaterial" id=7]
+[sub_resource type="SpatialMaterial" id=4]
 
-[sub_resource type="Shader" id=8]
+[sub_resource type="Shader" id=5]
 code = "shader_type spatial;
 
 uniform vec2 size;
@@ -38,8 +39,8 @@ void fragment()
 	ALBEDO = color;
 }"
 
-[sub_resource type="ShaderMaterial" id=9]
-shader = SubResource( 8 )
+[sub_resource type="ShaderMaterial" id=6]
+shader = SubResource( 5 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/tile_color = Color( 1, 0.58, 0.43, 1 )
 shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
@@ -49,6 +50,7 @@ shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
 [node name="Camera" type="Camera" parent="."]
 transform = Transform( 1, 0, 0, 0, 0.461393, 0.887196, 0, -0.887196, 0.461393, 1.34645, 50.4642, 26.7106 )
 fov = 36.6
+script = ExtResource( 2 )
 
 [node name="Player" type="KinematicBody" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0 )
@@ -97,7 +99,7 @@ anchor_top = 1.0
 anchor_right = 1.0
 anchor_bottom = 1.0
 margin_top = -14.0
-custom_styles/fg = SubResource( 6 )
+custom_styles/fg = SubResource( 3 )
 max_value = 1.0
 __meta__ = {
 "_edit_use_anchors_": false
@@ -122,5 +124,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.91746, 2.16162, -3.4431 )
 script = ExtResource( 7 )
 UnitSize = 4
 MapPath = "res://Maps/basic2.data"
-WallMaterial = SubResource( 7 )
-FloorMaterial = SubResource( 9 )
+WallMaterial = SubResource( 4 )
+FloorMaterial = SubResource( 6 )

--- a/Scripts/PlayerCamera.cs
+++ b/Scripts/PlayerCamera.cs
@@ -1,44 +1,78 @@
 using Godot;
-using System;
 
 public class PlayerCamera : Camera
 {
     [Export]
-    private float CloseDistThreshold = 4f;
+    private readonly float PlayerDistanceThreshold = 2f;
     [Export]
-    private float FarDistThreshold = 6f;
+    private readonly float CursorDistanceThreshold = 1f;
     [Export]
-    private float OffsetZ = 25f;
+    private readonly float OffsetZ = 25f;
     [Export]
-    private float Height = 50f;
+    private readonly float Height = 50f;
+    [Export]
+    private readonly float LookRange = 5.0f;
+    [Export]
+    private readonly float FollowCursorSpeedFactor = 0.3f;
+    [Export]
+    private readonly float FollowPlayerSpeedFactor = 0.7f;
+    [Export]
+    private readonly float VelocityDamping = 0.9f;
+
     private Player player;
     private float TargetHeight;
+    private Vector3 followCursorVelocity;
+    private Vector3 followPlayerVelocity;
+    private Vector3 currentCursorOffset;
+
     public override void _Ready()
     {
         player = GetNodeOrNull<Player>("../Player");
         TargetHeight = Height;
+        followCursorVelocity = new Vector3();
+        followPlayerVelocity = new Vector3();
+        currentCursorOffset = new Vector3();
     }
+
     public override void _PhysicsProcess(float delta)
     {
-        Vector3 moveDirection = Vector3.Zero;
-
-        Vector3 distFromPlayer = GlobalTransform.origin - player.GlobalTransform.origin;
-        float distX = distFromPlayer.x;
-        float distZ = distFromPlayer.z - OffsetZ;
-
-        float midDistThreshold = (FarDistThreshold + CloseDistThreshold) / 2;
-        if (distX > FarDistThreshold || distX < CloseDistThreshold)
-            moveDirection.x = midDistThreshold - distX;
-        if (distZ > FarDistThreshold || distZ < CloseDistThreshold)
-            moveDirection.z = midDistThreshold - distZ;
-
         if (player.IsMovementLocked)
-            TargetHeight = Height / 2;
+            TargetHeight = Height * 0.75f;
         else
             TargetHeight = Height;
 
-        moveDirection.y = TargetHeight - distFromPlayer.y;
+        Vector3 playerTranslation = player.GlobalTransform.origin;
+        Vector3 currentTranslation = GlobalTransform.origin - currentCursorOffset;
+        Vector3 targetTranslation = new Vector3(playerTranslation.x, TargetHeight, playerTranslation.z + OffsetZ);
+        Vector2 cursorPosition = player.GetWeightedAttackDirection();
 
-        Translation += moveDirection * delta;
+        Vector3 targetCursorOffset = new Vector3(cursorPosition.x, 0, cursorPosition.y) * LookRange;
+        Vector3 followPlayerDirection = targetTranslation - currentTranslation;
+        Vector3 followCursorDirection = targetCursorOffset - currentCursorOffset;
+
+        followPlayerDirection = Threshold(followPlayerDirection, PlayerDistanceThreshold);
+        followCursorDirection = Threshold(followCursorDirection, CursorDistanceThreshold);
+
+        followPlayerVelocity += followPlayerDirection;
+        followCursorVelocity += followCursorDirection;
+
+        followPlayerVelocity *= VelocityDamping;
+        followCursorVelocity *= VelocityDamping;
+
+        currentCursorOffset += (followCursorVelocity * FollowCursorSpeedFactor) * delta;
+
+        Transform transform = GlobalTransform;
+        transform.origin += (followPlayerVelocity * FollowPlayerSpeedFactor + followCursorVelocity * FollowCursorSpeedFactor) * delta;
+        GlobalTransform = transform;
+    }
+
+    private static Vector3 Threshold(Vector3 vector, float threshold)
+    {
+        if (vector.Length() <= threshold)
+            return Vector3.Zero;
+        else
+        {
+            return vector.Normalized() * (vector.Length() - threshold);
+        }
     }
 }

--- a/Scripts/PlayerCamera.cs
+++ b/Scripts/PlayerCamera.cs
@@ -1,0 +1,45 @@
+using Godot;
+using System;
+
+public class PlayerCamera : Camera
+{
+    [Export]
+    private float CloseDistThreshold = 4f;
+    [Export]
+    private float FarDistThreshold = 6f;
+    [Export]
+    private float OffsetZ = 25f;
+    [Export]
+    private float Height = 50f;
+    private Player player;
+    private float EPSILON = 0.0001f;
+    private float TargetHeight;
+    public override void _Ready()
+    {
+        player = GetNodeOrNull<Player>("../Player");
+        TargetHeight = Height;
+    }
+    public override void _PhysicsProcess(float delta)
+    {
+        Vector3 moveDirection = Vector3.Zero;
+
+        Vector3 distFromPlayer = GlobalTransform.origin - player.GlobalTransform.origin;
+        float distX = distFromPlayer.x;
+        float distZ = distFromPlayer.z - OffsetZ;
+
+        float midDistThreshold = (FarDistThreshold + CloseDistThreshold) / 2;
+        if (distX > FarDistThreshold || distX < CloseDistThreshold)
+            moveDirection.x = midDistThreshold - distX;
+        if (distZ > FarDistThreshold || distZ < CloseDistThreshold)
+            moveDirection.z = midDistThreshold - distZ;
+
+        if (player.IsMovementLocked)
+            TargetHeight = Height / 2;
+        else
+            TargetHeight = Height;
+
+        moveDirection.y = TargetHeight - distFromPlayer.y;
+
+        Translation += moveDirection * delta;
+    }
+}

--- a/Scripts/PlayerCamera.cs
+++ b/Scripts/PlayerCamera.cs
@@ -12,7 +12,6 @@ public class PlayerCamera : Camera
     [Export]
     private float Height = 50f;
     private Player player;
-    private float EPSILON = 0.0001f;
     private float TargetHeight;
     public override void _Ready()
     {

--- a/Scripts/PlayerCamera.cs
+++ b/Scripts/PlayerCamera.cs
@@ -3,7 +3,7 @@ using Godot;
 public class PlayerCamera : Camera
 {
     [Export]
-    private readonly float PlayerDistanceThreshold = 2f;
+    private readonly float PlayerDistanceThreshold = 3f;
     [Export]
     private readonly float CursorDistanceThreshold = 1f;
     [Export]
@@ -15,7 +15,7 @@ public class PlayerCamera : Camera
     [Export]
     private readonly float FollowCursorSpeedFactor = 0.3f;
     [Export]
-    private readonly float FollowPlayerSpeedFactor = 0.7f;
+    private readonly float FollowPlayerSpeedFactor = 0.25f;
     [Export]
     private readonly float VelocityDamping = 0.9f;
 
@@ -24,6 +24,7 @@ public class PlayerCamera : Camera
     private Vector3 followCursorVelocity;
     private Vector3 followPlayerVelocity;
     private Vector3 currentCursorOffset;
+    private Tween tween;
 
     public override void _Ready()
     {
@@ -32,14 +33,13 @@ public class PlayerCamera : Camera
         followCursorVelocity = new Vector3();
         followPlayerVelocity = new Vector3();
         currentCursorOffset = new Vector3();
+        tween = new Tween();
+        AddChild(tween);
     }
 
     public override void _PhysicsProcess(float delta)
     {
-        if (player.IsMovementLocked)
-            TargetHeight = Height * 0.75f;
-        else
-            TargetHeight = Height;
+        TargetHeight = Height;
 
         Vector3 playerTranslation = player.GlobalTransform.origin;
         Vector3 currentTranslation = GlobalTransform.origin - currentCursorOffset;


### PR DESCRIPTION
Partially complete #96 

There is a close and far distance threshold, such that the camera will move to follow the player if its direction on the x or z axis is outside that range. In this case, the camera will move towards the midpoint of the range, with the speed being proportional to the distance from it. The calculations for the x and z axis are done independently.

Additionally, similar calculations are used to move the camera to half its height from the player when the player is dashing.