### PR TITLE
Bug fixes for Player and DashSkill

### DIFF
--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -248,20 +248,8 @@ public class Player : HealthEntity
     {
         Vector3 cameraRayOrigin = camera.ProjectRayOrigin(mousePosition);
         Vector3 rayDirection = camera.ProjectRayNormal(mousePosition);
-        Vector3 cameraRayTarget = cameraRayOrigin + (rayDirection * 1000);
-        Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(cameraRayOrigin, cameraRayTarget, collisionMask: 1);
-        if (ray.Count > 0)
-        {
-            Vector3 cursorPointOnFloor = (Vector3)ray["position"];
-            Vector3 directionToCamera = -rayDirection;
-            float heightDifference = Mathf.Abs(GlobalTransform.origin.y - cursorPointOnFloor.y);
-
-            // Backtrack ray to camera such that cursorPosition.y = player.y
-            Vector3 cursorPointOnPlayerPlane = cursorPointOnFloor + (heightDifference / directionToCamera.y) * directionToCamera;
-
-            return cursorPointOnPlayerPlane;
-        }
-        return null;
+        float factor = (GlobalTransform.origin.y - cameraRayOrigin.y) / rayDirection.y;
+        return cameraRayOrigin + rayDirection * factor;
     }
 
     protected override void Die()

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -198,8 +198,8 @@ public class DashSkill : AimableAttack
             Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(currentLocation, targetLocation, collisionMask: 1);
             if (ray.Count > 0)
             {
-                Vector3 wallNormal = (Vector3) ray["normal"];
-                Vector3 position = (Vector3) ray["position"];
+                Vector3 wallNormal = (Vector3)ray["normal"];
+                Vector3 position = (Vector3)ray["position"];
                 float cosAngle = wallNormal.Dot(GlobalTransform.basis.z);
                 float radius = player.Scale.x;
                 float hyp = radius / cosAngle;

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -193,7 +193,26 @@ public class DashSkill : AimableAttack
         Vector3 targetLocation;
         if (targetEnemy == null)
         {
-            targetLocation = currentLocation + range * (-GlobalTransform.basis.z);
+            float largeNum = 1000.0f;
+            targetLocation = currentLocation + largeNum * (-GlobalTransform.basis.z);
+            Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(currentLocation, targetLocation, collisionMask: 1);
+            if (ray.Count > 0)
+            {
+                Vector3 wallNormal = (Vector3) ray["normal"];
+                Vector3 position = (Vector3) ray["position"];
+                float cosAngle = wallNormal.Dot(GlobalTransform.basis.z);
+                float radius = player.Scale.x;
+                float hyp = radius / cosAngle;
+                // cosAngle should not be 90 degrees as that would mean that
+                // player is moving parallel to the wall hence ray would not intersect
+                targetLocation = position + hyp * GlobalTransform.basis.z;
+                if ((targetLocation - currentLocation).Length() > range)
+                    targetLocation = currentLocation + range * (-GlobalTransform.basis.z);
+            }
+            else
+            {
+                targetLocation = currentLocation + range * (-GlobalTransform.basis.z);
+            }
         }
         else
         {

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -193,15 +193,14 @@ public class DashSkill : AimableAttack
         Vector3 targetLocation;
         if (targetEnemy == null)
         {
-            float largeNum = 1000.0f;
-            targetLocation = currentLocation + largeNum * (-GlobalTransform.basis.z);
+            float radius = player.Scale.x;
+            targetLocation = currentLocation + (range + radius) * (-GlobalTransform.basis.z);
             Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(currentLocation, targetLocation, collisionMask: 1);
             if (ray.Count > 0)
             {
                 Vector3 wallNormal = (Vector3)ray["normal"];
                 Vector3 position = (Vector3)ray["position"];
                 float cosAngle = wallNormal.Dot(GlobalTransform.basis.z);
-                float radius = player.Scale.x;
                 float hyp = radius / cosAngle;
                 // cosAngle should not be 90 degrees as that would mean that
                 // player is moving parallel to the wall hence ray would not intersect

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,11 @@ config/name="Coma Dash"
 run/main_scene="res://Scenes/MainLevel.tscn"
 config/icon="res://icon.png"
 
+[display]
+
+window/stretch/mode="2d"
+window/stretch/aspect="expand"
+
 [input]
 
 ui_accept={


### PR DESCRIPTION
When using the dash skill, if there is no target enemy, cast ray to check for collisions with walls.

Refactored GetCursorPointOnPlayerPlane. Previously had bug as ray could intersect with the walls which are not on the player plane, causing the player to move in the y direction. Ray tracing is superfluous in that function. 