### PR TITLE
Dash: Check if ray intersection with the enemy exists

### DIFF
--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -209,6 +209,8 @@ public class DashSkill : AimableAttack
         }
         else
         {
+            // Set target enemy to null if it has somehow disappeared
+            targetEnemy = null;
             float radius = player.Scale.x;
             targetLocation = currentLocation + (range + radius) * (-GlobalTransform.basis.z);
             Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(currentLocation, targetLocation, collisionMask: 1);

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -191,7 +191,23 @@ public class DashSkill : AimableAttack
             return;
         Vector3 currentLocation = GlobalTransform.origin;
         Vector3 targetLocation;
-        if (targetEnemy == null)
+
+        Dictionary rayToEnemy = null;
+
+        // Check if enemy still exists before going to it
+        // It could have died or moved away at this point
+        if (targetEnemy != null)
+        {
+            Vector3 enemyLocation = targetEnemy.GlobalTransform.origin;
+            rayToEnemy = GetWorld().DirectSpaceState.IntersectRay(currentLocation, enemyLocation, collisionMask: 4);
+        }
+
+        if (rayToEnemy != null && rayToEnemy.Count > 0)
+        {
+            Vector3 enemyBoundary = (Vector3)rayToEnemy["position"];
+            targetLocation = enemyBoundary + player.Scale * GlobalTransform.basis.z;
+        }
+        else
         {
             float radius = player.Scale.x;
             targetLocation = currentLocation + (range + radius) * (-GlobalTransform.basis.z);
@@ -212,15 +228,6 @@ public class DashSkill : AimableAttack
             {
                 targetLocation = currentLocation + range * (-GlobalTransform.basis.z);
             }
-        }
-        else
-        {
-            Vector3 enemyLocation = targetEnemy.GlobalTransform.origin;
-            Dictionary ray = GetWorld().DirectSpaceState.IntersectRay(currentLocation, enemyLocation, collisionMask: 4);
-            Vector3 enemyBoundary = (Vector3)ray["position"];
-
-            // Go right up beside enemy
-            targetLocation = enemyBoundary + player.Scale * GlobalTransform.basis.z;
         }
 
         Transform currentTransform = player.GlobalTransform;


### PR DESCRIPTION
Because targetEnemy was set some time before OnAttackButtonReleased is executed, the enemy could have died or moved away at this point. In this case, the ray would not intersect with anything, causing the dictionary to not have the "position" key and the game will crash.

```
Unhandled Exception:
System.Collections.Generic.KeyNotFoundException: The given key was not present in the dictionary.
  at (wrapper managed-to-native) Godot.Collections.Dictionary.godot_icall_Dictionary_GetValue(intptr,object)
  at Godot.Collections.Dictionary.get_Item (System.Object key) [0x00000] in /root/godot/modules/mono/glue/GodotSharp/GodotSharp/Core/Dictionary.cs:114
  at DashSkill.OnAttackButtonReleased () [0x001b9] in /Users/daniellimws/coma-dash/Scripts/Weapon/DashSkill.cs:220
  at AimableAttack.set_IsAttackButtonPressed (System.Boolean value) [0x0001d] in /Users/daniellimws/coma-dash/Scripts/Weapon/AimableAttack.cs:38
  at Player._PhysicsProcess (System.Single delta) [0x000cd] in /Users/daniellimws/coma-dash/Scripts/Player.cs:126
```