### PR TITLE
Outline shader

### DIFF
--- a/Scenes/Enemy.tscn
+++ b/Scenes/Enemy.tscn
@@ -1,16 +1,19 @@
-[gd_scene load_steps=3 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Scripts/Enemy/Enemy.cs" type="Script" id=1]
 
 [sub_resource type="CylinderShape" id=1]
+
+[sub_resource type="CylinderMesh" id=2]
 
 [node name="Enemy" type="KinematicBody"]
 collision_layer = 4
 collision_mask = 9
 script = ExtResource( 1 )
 
-[node name="CSGCylinder" type="CSGCylinder" parent="."]
-height = 2.0
-
 [node name="CollisionShape" type="CollisionShape" parent="."]
 shape = SubResource( 1 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )
+material/0 = null

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -7,35 +7,35 @@
 [ext_resource path="res://Scenes/Enemy.tscn" type="PackedScene" id=5]
 [ext_resource path="res://Scripts/Weapon/DashSkill.cs" type="Script" id=6]
 [ext_resource path="res://Scripts/Generator/MapLoader.cs" type="Script" id=7]
-[ext_resource path="res://Scenes/Outline.shader" type="Shader" id=8]
+[ext_resource path="res://Shaders/Outline.shader" type="Shader" id=8]
 
-[sub_resource type="ShaderMaterial" id=11]
+[sub_resource type="ShaderMaterial" id=1]
 shader = ExtResource( 8 )
 shader_param/scale = 2.0
 shader_param/threshold = 2.0
 shader_param/color = Color( 0, 0, 0, 1 )
 shader_param/enabled = true
 
-[sub_resource type="QuadMesh" id=1]
-material = SubResource( 11 )
+[sub_resource type="QuadMesh" id=2]
+material = SubResource( 1 )
 size = Vector2( 2, 2 )
 
-[sub_resource type="CylinderShape" id=4]
+[sub_resource type="CylinderShape" id=3]
 
-[sub_resource type="BoxShape" id=5]
+[sub_resource type="BoxShape" id=4]
 
-[sub_resource type="DynamicFontData" id=6]
+[sub_resource type="DynamicFontData" id=5]
 font_path = "res://Fonts/PermanentMarker-Regular.ttf"
 
-[sub_resource type="DynamicFont" id=7]
+[sub_resource type="DynamicFont" id=6]
 size = 23
 outline_size = 3
 outline_color = Color( 0, 0, 0, 1 )
-font_data = SubResource( 6 )
+font_data = SubResource( 5 )
 
-[sub_resource type="SpatialMaterial" id=8]
+[sub_resource type="SpatialMaterial" id=7]
 
-[sub_resource type="Shader" id=9]
+[sub_resource type="Shader" id=8]
 code = "shader_type spatial;
 
 uniform vec2 size;
@@ -57,8 +57,8 @@ void fragment()
 	ALBEDO = color;
 }"
 
-[sub_resource type="ShaderMaterial" id=10]
-shader = SubResource( 9 )
+[sub_resource type="ShaderMaterial" id=9]
+shader = SubResource( 8 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/tile_color = Color( 1, 0.58, 0.43, 1 )
 shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
@@ -71,7 +71,7 @@ fov = 35.0
 script = ExtResource( 2 )
 
 [node name="OutlineEffect" type="MeshInstance" parent="Camera"]
-mesh = SubResource( 1 )
+mesh = SubResource( 2 )
 material/0 = null
 
 [node name="Player" type="KinematicBody" parent="."]
@@ -84,7 +84,7 @@ script = ExtResource( 1 )
 height = 2.0
 
 [node name="CollisionShape" type="CollisionShape" parent="Player"]
-shape = SubResource( 4 )
+shape = SubResource( 3 )
 
 [node name="Weapon" type="Spatial" parent="Player"]
 script = ExtResource( 4 )
@@ -101,7 +101,7 @@ transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, 0, 0 )
 collision_mask = 15
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-shape = SubResource( 5 )
+shape = SubResource( 4 )
 
 [node name="RoomGenerator" type="Spatial" parent="."]
 
@@ -131,7 +131,7 @@ __meta__ = {
 [node name="Heat" type="Label" parent="GUI/VBoxContainer"]
 margin_right = 824.0
 margin_bottom = 34.0
-custom_fonts/font = SubResource( 7 )
+custom_fonts/font = SubResource( 6 )
 text = "Heat"
 align = 1
 valign = 1
@@ -195,5 +195,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.91746, 2.16162, -3.4431 )
 script = ExtResource( 7 )
 UnitSize = 4
 MapPath = "res://Maps/basic2.data"
-WallMaterial = SubResource( 8 )
-FloorMaterial = SubResource( 10 )
+WallMaterial = SubResource( 7 )
+FloorMaterial = SubResource( 9 )

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -13,7 +13,7 @@
 shader = ExtResource( 8 )
 shader_param/scale = 2.0
 shader_param/threshold = 2.0
-shader_param/color = Vector3( 0, 0, 0 )
+shader_param/color = Color( 0, 0, 0, 1 )
 shader_param/enabled = true
 
 [sub_resource type="QuadMesh" id=1]

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=2]
+[gd_scene load_steps=18 format=2]
 
 [ext_resource path="res://Scripts/Player.cs" type="Script" id=1]
 [ext_resource path="res://Scripts/PlayerCamera.cs" type="Script" id=2]
@@ -7,23 +7,35 @@
 [ext_resource path="res://Scenes/Enemy.tscn" type="PackedScene" id=5]
 [ext_resource path="res://Scripts/Weapon/DashSkill.cs" type="Script" id=6]
 [ext_resource path="res://Scripts/Generator/MapLoader.cs" type="Script" id=7]
+[ext_resource path="res://Scenes/Outline.shader" type="Shader" id=8]
 
-[sub_resource type="CylinderShape" id=1]
+[sub_resource type="ShaderMaterial" id=11]
+shader = ExtResource( 8 )
+shader_param/scale = 2.0
+shader_param/threshold = 2.0
+shader_param/color = Vector3( 0, 0, 0 )
+shader_param/enabled = true
 
-[sub_resource type="BoxShape" id=2]
+[sub_resource type="QuadMesh" id=1]
+material = SubResource( 11 )
+size = Vector2( 2, 2 )
 
-[sub_resource type="DynamicFontData" id=3]
+[sub_resource type="CylinderShape" id=4]
+
+[sub_resource type="BoxShape" id=5]
+
+[sub_resource type="DynamicFontData" id=6]
 font_path = "res://Fonts/PermanentMarker-Regular.ttf"
 
-[sub_resource type="DynamicFont" id=4]
+[sub_resource type="DynamicFont" id=7]
 size = 23
 outline_size = 3
 outline_color = Color( 0, 0, 0, 1 )
-font_data = SubResource( 3 )
+font_data = SubResource( 6 )
 
-[sub_resource type="SpatialMaterial" id=5]
+[sub_resource type="SpatialMaterial" id=8]
 
-[sub_resource type="Shader" id=6]
+[sub_resource type="Shader" id=9]
 code = "shader_type spatial;
 
 uniform vec2 size;
@@ -45,8 +57,8 @@ void fragment()
 	ALBEDO = color;
 }"
 
-[sub_resource type="ShaderMaterial" id=7]
-shader = SubResource( 6 )
+[sub_resource type="ShaderMaterial" id=10]
+shader = SubResource( 9 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/tile_color = Color( 1, 0.58, 0.43, 1 )
 shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
@@ -58,6 +70,10 @@ transform = Transform( 1, 0, 0, 0, 0.461393, 0.887196, 0, -0.887196, 0.461393, 1
 fov = 35.0
 script = ExtResource( 2 )
 
+[node name="OutlineEffect" type="MeshInstance" parent="Camera"]
+mesh = SubResource( 1 )
+material/0 = null
+
 [node name="Player" type="KinematicBody" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2, 0 )
 collision_layer = 2
@@ -68,7 +84,7 @@ script = ExtResource( 1 )
 height = 2.0
 
 [node name="CollisionShape" type="CollisionShape" parent="Player"]
-shape = SubResource( 1 )
+shape = SubResource( 4 )
 
 [node name="Weapon" type="Spatial" parent="Player"]
 script = ExtResource( 4 )
@@ -85,7 +101,7 @@ transform = Transform( 100, 0, 0, 0, 1, 0, 0, 0, 100, 0, 0, 0 )
 collision_mask = 15
 
 [node name="CollisionShape" type="CollisionShape" parent="Floor"]
-shape = SubResource( 2 )
+shape = SubResource( 5 )
 
 [node name="RoomGenerator" type="Spatial" parent="."]
 
@@ -115,7 +131,7 @@ __meta__ = {
 [node name="Heat" type="Label" parent="GUI/VBoxContainer"]
 margin_right = 824.0
 margin_bottom = 34.0
-custom_fonts/font = SubResource( 4 )
+custom_fonts/font = SubResource( 7 )
 text = "Heat"
 align = 1
 valign = 1
@@ -179,5 +195,5 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 7.91746, 2.16162, -3.4431 )
 script = ExtResource( 7 )
 UnitSize = 4
 MapPath = "res://Maps/basic2.data"
-WallMaterial = SubResource( 5 )
-FloorMaterial = SubResource( 7 )
+WallMaterial = SubResource( 8 )
+FloorMaterial = SubResource( 10 )

--- a/Scenes/Outline.shader
+++ b/Scenes/Outline.shader
@@ -3,15 +3,15 @@ render_mode unshaded;
 
 uniform float scale = 2.0;
 uniform float threshold = 2.0;
-uniform vec3 color = vec3(0, 0, 0);
+uniform vec4 color : hint_color = vec4(0, 0, 0, 1);
 uniform bool enabled = true;
 
-varying mat4 CAMERA;
+// varying mat4 CAMERA;
 
 void vertex() 
 {
 	POSITION = vec4(VERTEX, 1.0);
-	CAMERA = CAMERA_MATRIX;
+	// CAMERA = CAMERA_MATRIX;
 }
 
 float depth_calc(vec2 uv, sampler2D depth_tex, mat4 inv_projection_mat) 
@@ -46,8 +46,8 @@ void fragment()
 	dist = sqrt(dist);
 	if (dist > threshold && enabled)
 	{
-		ALBEDO = color;
-		ALPHA = 1.0;
+		ALBEDO = color.rgb;
+		ALPHA = color.a;
 	}
 	else
 	{

--- a/Scenes/Outline.shader
+++ b/Scenes/Outline.shader
@@ -45,7 +45,12 @@ void fragment()
 	// See: https://roystan.net/articles/outline-shader.html
 	dist = sqrt(dist);
 	if (dist > threshold && enabled)
+	{
 		ALBEDO = color;
+		ALPHA = 1.0;
+	}
 	else
-		ALBEDO = texture(SCREEN_TEXTURE, uv).rgb;
+	{
+		ALPHA = 0.0;
+	}
 }

--- a/Scenes/Outline.shader
+++ b/Scenes/Outline.shader
@@ -1,0 +1,51 @@
+shader_type spatial;
+render_mode unshaded;
+
+uniform float scale = 2.0;
+uniform float threshold = 2.0;
+uniform vec3 color = vec3(0, 0, 0);
+uniform bool enabled = true;
+
+varying mat4 CAMERA;
+
+void vertex() 
+{
+	POSITION = vec4(VERTEX, 1.0);
+	CAMERA = CAMERA_MATRIX;
+}
+
+float depth_calc(vec2 uv, sampler2D depth_tex, mat4 inv_projection_mat) 
+{
+	// based on: https://docs.godotengine.org/en/stable/tutorials/shading/advanced_postprocessing.html
+	float d = texture(depth_tex, uv).r;
+	vec3 ndc = vec3(uv, d) * 2.0 - 1.0;
+	vec4 view = inv_projection_mat * vec4(ndc, 1.0);
+  	view.xyz /= view.w;
+	// For future use: computing world coordinates
+	// vec4 world = CAMERA * inv_projection_mat * vec4(ndc, 1.0);
+  	// vec3 world_position = world.xyz / world.w;
+  	float linear_depth = -view.z;
+	return linear_depth;
+}
+
+float diff_sq(vec2 uv, vec2 dir, sampler2D depth_tex, mat4 inv_projection_mat) {
+	float d1 = depth_calc(uv + dir, depth_tex, inv_projection_mat);
+	float d2 = depth_calc(uv - dir, depth_tex, inv_projection_mat);
+	return (d1 - d2) * (d1 - d2);
+}
+
+void fragment() 
+{	
+	vec2 uv = SCREEN_UV;
+	float offset = 0.001 * scale;
+	float dist = 
+		diff_sq(uv, vec2(offset, offset), DEPTH_TEXTURE, INV_PROJECTION_MATRIX) + 
+		diff_sq(uv, vec2(-offset, offset), DEPTH_TEXTURE, INV_PROJECTION_MATRIX);
+	// Once Godot supports accessing the normal maps, more enhancements can be made
+	// See: https://roystan.net/articles/outline-shader.html
+	dist = sqrt(dist);
+	if (dist > threshold && enabled)
+		ALBEDO = color;
+	else
+		ALBEDO = texture(SCREEN_TEXTURE, uv).rgb;
+}

--- a/Scripts/Enemy/Enemy.cs
+++ b/Scripts/Enemy/Enemy.cs
@@ -17,11 +17,11 @@ public class Enemy : HealthEntity
         material = new SpatialMaterial()
         {
             AlbedoColor = Colors.White,
-            FlagsTransparent = true
+            FlagsTransparent = false
         };
 
-        CSGCylinder cylinder = GetNode<CSGCylinder>("CSGCylinder");
-        cylinder.Material = material;
+        MeshInstance cylinder = GetNode<MeshInstance>("MeshInstance");
+        cylinder.SetSurfaceMaterial(0, material);
     }
 
     public override void _PhysicsProcess(float delta)
@@ -38,6 +38,7 @@ public class Enemy : HealthEntity
 
     protected override void Die()
     {
+        material.FlagsTransparent = true;
         Tween tween = new Tween();
         AddChild(tween);
         tween.InterpolateProperty(material, "albedo_color:a", 0.5f, 0, 1.0f);

--- a/Shaders/Outline.shader
+++ b/Shaders/Outline.shader
@@ -1,0 +1,56 @@
+shader_type spatial;
+render_mode unshaded;
+
+uniform float scale = 2.0;
+uniform float threshold = 2.0;
+uniform vec4 color : hint_color = vec4(0, 0, 0, 1);
+uniform bool enabled = true;
+
+// varying mat4 CAMERA;
+
+void vertex() 
+{
+	POSITION = vec4(VERTEX, 1.0);
+	// CAMERA = CAMERA_MATRIX;
+}
+
+float depth_calc(vec2 uv, sampler2D depth_tex, mat4 inv_projection_mat) 
+{
+	// based on: https://docs.godotengine.org/en/stable/tutorials/shading/advanced_postprocessing.html
+	float d = texture(depth_tex, uv).r;
+	vec3 ndc = vec3(uv, d) * 2.0 - 1.0;
+	vec4 view = inv_projection_mat * vec4(ndc, 1.0);
+  	view.xyz /= view.w;
+	// For future use: computing world coordinates
+	// vec4 world = CAMERA * inv_projection_mat * vec4(ndc, 1.0);
+  	// vec3 world_position = world.xyz / world.w;
+  	float linear_depth = -view.z;
+	return linear_depth;
+}
+
+float diff_sq(vec2 uv, vec2 dir, sampler2D depth_tex, mat4 inv_projection_mat) {
+	float d1 = depth_calc(uv + dir, depth_tex, inv_projection_mat);
+	float d2 = depth_calc(uv - dir, depth_tex, inv_projection_mat);
+	return (d1 - d2) * (d1 - d2);
+}
+
+void fragment() 
+{	
+	vec2 uv = SCREEN_UV;
+	float offset = 0.001 * scale;
+	float dist = 
+		diff_sq(uv, vec2(offset, offset), DEPTH_TEXTURE, INV_PROJECTION_MATRIX) + 
+		diff_sq(uv, vec2(-offset, offset), DEPTH_TEXTURE, INV_PROJECTION_MATRIX);
+	// Once Godot supports accessing the normal maps, more enhancements can be made
+	// See: https://roystan.net/articles/outline-shader.html
+	dist = sqrt(dist);
+	if (dist > threshold && enabled)
+	{
+		ALBEDO = color.rgb;
+		ALPHA = color.a;
+	}
+	else
+	{
+		ALPHA = 0.0;
+	}
+}


### PR DESCRIPTION
#51 Outline handler is situated right in front of the camera and covers the whole viewport.
It accesses the depth buffer and does a simple edge detection algorithm. Can set shader parameters for the thickness of the outline, threshold for the outline, enable/disable outline and outline colour.

Note: Objects with transparency are rendered in a different pipeline thus do not get any outlines. Can be considered bug and feature. 

Changes in enemy required: set the transparent flag only when enemy dies, so that the enemy has outline before dying and can still fade out of scene.