### PR TITLE
HealthEntity: Only update healthbars when Health > 0

### DIFF
--- a/Scripts/HealthEntity.cs
+++ b/Scripts/HealthEntity.cs
@@ -141,13 +141,16 @@ public abstract class HealthEntity : KinematicBody, IStatusHolder
     private void DisplayHealthBar()
     {
         Vector2 positionOnScreen = camera.UnprojectPosition(GlobalTransform.origin);
+        if (Health > 0)
+        {
+            Vector2 size = healthBar.RectSize;
+            Vector2 scale = healthBar.RectScale;
 
-        Vector2 size = healthBar.RectSize;
-        Vector2 scale = healthBar.RectScale;
+            Vector2 healthBarPosition = positionOnScreen + new Vector2(-size.x * scale.x / 2, -size.y * scale.y) + Vector2.Up * 10;
 
-        Vector2 healthBarPosition = positionOnScreen + new Vector2(-size.x * scale.x / 2, -size.y * scale.y) + Vector2.Up * 10;
-        healthBar.RectPosition = healthBarPosition;
-        whiteHealthBar.RectPosition = healthBarPosition;
+            healthBar.RectPosition = healthBarPosition;
+            whiteHealthBar.RectPosition = healthBarPosition;
+        }
     }
 
     public virtual void Damage(float damage)


### PR DESCRIPTION
There is an error when trying to update the healthbars when they are already freed when health is 0. This does not cause the game to crash but it is good to fix for good programming hygiene.

![image](https://user-images.githubusercontent.com/8130120/81313712-cdd7a500-90ba-11ea-8302-d0b36a1b25ed.png)
