### PR TITLE
MapLoader: Connect rooms with the doors next to them

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -64,7 +64,10 @@
     <Compile Include="Scripts\Enemy\Enemy.cs" />
     <Compile Include="Scripts\Enemy\EnemyPencil.cs" />
     <Compile Include="Scripts\Generator\Door.cs" />
+    <Compile Include="Scripts\Generator\LevelRegion.cs" />
     <Compile Include="Scripts\Generator\MapLoader.cs" />
+    <Compile Include="Scripts\Generator\RegionLabel.cs" />
+    <Compile Include="Scripts\Generator\RegionParseInfo.cs" />
     <Compile Include="Scripts\Generator\RoomGenerator.cs" />
     <Compile Include="Scripts\Generator\Room.cs" />
     <Compile Include="Scripts\Generator\Wall.cs" />

--- a/Scripts/Generator/Door.cs
+++ b/Scripts/Generator/Door.cs
@@ -1,13 +1,14 @@
 using System;
 using Godot;
 
-public class Door : StaticBody
+public class Door : LevelRegion
 {
+    private CSGPolygon doorMesh;
     public Door(Vector2[][] polygon, int unitSize)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
-        CSGPolygon doorMesh = new CSGPolygon
+        doorMesh = new CSGPolygon
         {
             Polygon = polygon[0]
         };
@@ -20,5 +21,19 @@ public class Door : StaticBody
         doorMesh.UseCollision = true;
         doorMesh.CollisionLayer = 1;
         doorMesh.CollisionMask = 1;
+    }
+
+    public void Open()
+    {
+        // TODO: Add animations or effects
+        doorMesh.UseCollision = false;
+        doorMesh.Visible = false;
+    }
+
+    public void Close()
+    {
+        // TODO: Add animations or effects
+        doorMesh.UseCollision = true;
+        doorMesh.Visible = true;
     }
 }

--- a/Scripts/Generator/Door.cs
+++ b/Scripts/Generator/Door.cs
@@ -19,8 +19,8 @@ public class Door : LevelRegion
         AddChild(doorMesh);
 
         doorMesh.UseCollision = true;
-        doorMesh.CollisionLayer = 1;
-        doorMesh.CollisionMask = 1;
+        doorMesh.CollisionLayer = ColLayer.Environment;
+        doorMesh.CollisionMask = ColLayer.Environment;
     }
 
     public void Open()

--- a/Scripts/Generator/LevelRegion.cs
+++ b/Scripts/Generator/LevelRegion.cs
@@ -1,0 +1,6 @@
+using Godot;
+using System;
+
+public class LevelRegion : StaticBody
+{
+}

--- a/Scripts/Generator/LevelRegion.cs
+++ b/Scripts/Generator/LevelRegion.cs
@@ -1,5 +1,5 @@
-using Godot;
 using System;
+using Godot;
 
 public class LevelRegion : StaticBody
 {

--- a/Scripts/Generator/RegionLabel.cs
+++ b/Scripts/Generator/RegionLabel.cs
@@ -1,5 +1,5 @@
-using Godot;
 using System;
+using Godot;
 
 public enum RegionType
 {

--- a/Scripts/Generator/RegionLabel.cs
+++ b/Scripts/Generator/RegionLabel.cs
@@ -1,0 +1,18 @@
+using Godot;
+using System;
+
+public enum RegionType
+{
+    NONE, WALL, ROOM, DOOR
+}
+
+public class RegionLabel
+{
+    public RegionType Type { get; private set; }
+    public int Id { get; private set; }
+    public RegionLabel(RegionType type, int id)
+    {
+        Type = type;
+        Id = id;
+    }
+}

--- a/Scripts/Generator/RegionParseInfo.cs
+++ b/Scripts/Generator/RegionParseInfo.cs
@@ -1,10 +1,10 @@
-using Godot;
 using System;
+using Godot;
 
 public class RegionParseInfo
 {
-    public bool[,] Bitmap {get; private set;}
-    public Vector2[][] Polygon {get; private set;}
+    public bool[,] Bitmap { get; private set; }
+    public Vector2[][] Polygon { get; private set; }
 
     public RegionParseInfo(bool[,] bitmap, Vector2[][] polygon)
     {

--- a/Scripts/Generator/RegionParseInfo.cs
+++ b/Scripts/Generator/RegionParseInfo.cs
@@ -1,0 +1,14 @@
+using Godot;
+using System;
+
+public class RegionParseInfo
+{
+    public bool[,] Bitmap {get; private set;}
+    public Vector2[][] Polygon {get; private set;}
+
+    public RegionParseInfo(bool[,] bitmap, Vector2[][] polygon)
+    {
+        Bitmap = bitmap;
+        Polygon = polygon;
+    }
+}

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -1,12 +1,16 @@
 using System;
+using System.Collections.Generic;
 using Godot;
 
-public class Room : StaticBody
+public class Room : LevelRegion
 {
     private CSGPolygon floorMesh;
+    public HashSet<Door> ConnectedDoors { get; private set; }
 
     public Room(Vector2[][] polygon, int unitSize, Material material)
     {
+        ConnectedDoors = new HashSet<Door>();
+
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
         floorMesh = new CSGPolygon
@@ -28,6 +32,23 @@ public class Room : StaticBody
 
         AddChild(floorMesh);
         Translation = new Vector3(0, -unitSize, 0);
+
+        floorMesh.UseCollision = true;
+        floorMesh.CollisionLayer = 1;
+        floorMesh.CollisionMask = 1;
+    }
+
+    public override void _PhysicsProcess(float delta)
+    {
+        // Todo: Remove after EnemySpawner is implemented
+        if (Input.IsKeyPressed((int) KeyList.H))
+        {
+            OpenAllConnectedDoors();
+        }
+        if (Input.IsKeyPressed((int) KeyList.J))
+        {
+            CloseAllConnectedDoors();
+        }
     }
 
     private void SetFloorShaderParams(Vector2[] polygon, ShaderMaterial material)
@@ -51,5 +72,20 @@ public class Room : StaticBody
         ShaderMaterial dupMaterial = (ShaderMaterial)material.Duplicate();
         dupMaterial.SetShaderParam("size", new Vector2(width, height));
         floorMesh.Material = dupMaterial;
+    }
+
+    public void AddDoor(Door door)
+    {
+        ConnectedDoors.Add(door);
+    }
+
+    public void OpenAllConnectedDoors()
+    {
+        foreach (Door door in ConnectedDoors) door.Open();
+    }
+
+    public void CloseAllConnectedDoors()
+    {
+        foreach (Door door in ConnectedDoors) door.Close();
     }
 }

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -34,8 +34,8 @@ public class Room : LevelRegion
         Translation = new Vector3(0, -unitSize, 0);
 
         floorMesh.UseCollision = true;
-        floorMesh.CollisionLayer = 1;
-        floorMesh.CollisionMask = 1;
+        floorMesh.CollisionLayer = ColLayer.Environment;
+        floorMesh.CollisionMask = ColLayer.Environment;
     }
 
     public override void _PhysicsProcess(float delta)

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -41,11 +41,11 @@ public class Room : LevelRegion
     public override void _PhysicsProcess(float delta)
     {
         // Todo: Remove after EnemySpawner is implemented
-        if (Input.IsKeyPressed((int) KeyList.H))
+        if (Input.IsKeyPressed((int)KeyList.H))
         {
             OpenAllConnectedDoors();
         }
-        if (Input.IsKeyPressed((int) KeyList.J))
+        if (Input.IsKeyPressed((int)KeyList.J))
         {
             CloseAllConnectedDoors();
         }

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -1,7 +1,7 @@
 using System;
 using Godot;
 
-public class Wall : StaticBody
+public class Wall : LevelRegion
 {
     private readonly float WALL_HEIGHT = 2.2f;
     public Wall(Vector2[][] polygon, int unitSize, Material material)

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -28,7 +28,7 @@ public class Wall : LevelRegion
         }
         AddChild(wallMesh);
         wallMesh.UseCollision = true;
-        wallMesh.CollisionLayer = 1;
-        wallMesh.CollisionMask = 1;
+        wallMesh.CollisionLayer = ColLayer.Environment;
+        wallMesh.CollisionMask = ColLayer.Environment;
     }
 }


### PR DESCRIPTION
* Refactor the map parsing code to consider Wall/Room/Door as a Region. 
* Use a 2D map to store the type of region for each pixel. Then for each pixel, if it is a room, check if any of its neighbouring pixels are a door, and if so, connect the door with the room.
* Room class exposes public methods to open or close doors that are
connected to it.
* Temporarily assign keys H/J to open/close all doors for demo purposes.