### PR TITLE
Add MeleeEnemy, HP regeneration

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Scripts\Effects\OutlineEffect.cs" />
     <Compile Include="Scripts\Enemy\Enemy.cs" />
     <Compile Include="Scripts\Enemy\EnemyPencil.cs" />
+    <Compile Include="Scripts\Enemy\MeleeEnemy.cs" />
     <Compile Include="Scripts\Generator\Door.cs" />
     <Compile Include="Scripts\Generator\EnemySpawner.cs" />
     <Compile Include="Scripts\Generator\LevelRegion.cs" />

--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Scripts\PlayerCamera.cs" />
     <Compile Include="Scripts\Projectile.cs" />
     <Compile Include="Scripts\RunningCharacter.cs" />
+    <Compile Include="Scripts\StateManager.cs" />
     <Compile Include="Scripts\Status\MarkStatus.cs" />
     <Compile Include="Scripts\Status\Status.cs" />
     <Compile Include="Scripts\Status\IStatusHolder.cs" />

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -40,9 +40,6 @@ font_data = SubResource( 3 )
 [sub_resource type="StyleBoxFlat" id=6]
 bg_color = Color( 0.6, 0.6, 0.6, 0 )
 
-[sub_resource type="SpatialMaterial" id=9]
-albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
-
 [sub_resource type="Shader" id=7]
 code = "shader_type spatial;
 
@@ -70,6 +67,9 @@ shader = SubResource( 7 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/tile_color = Color( 1, 0.58, 0.43, 1 )
 shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
+
+[sub_resource type="SpatialMaterial" id=9]
+albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
 
 [node name="Level" type="Spatial"]
 
@@ -279,10 +279,10 @@ custom_styles/panel = SubResource( 6 )
 [node name="MapLoader" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -64, -1, -232 )
 script = ExtResource( 7 )
+FloorMaterial = SubResource( 8 )
+ShowPreview = true
 UnitSize = 4
 WallMaterial = SubResource( 9 )
-ShowPreview = true
-FloorMaterial = SubResource( 8 )
 MapPath = "res://Maps/map.data"
 
 [node name="DecorationShowcase" parent="." instance=ExtResource( 10 )]

--- a/Scenes/MainLevel.tscn
+++ b/Scenes/MainLevel.tscn
@@ -40,6 +40,9 @@ font_data = SubResource( 3 )
 [sub_resource type="StyleBoxFlat" id=6]
 bg_color = Color( 0.6, 0.6, 0.6, 0 )
 
+[sub_resource type="SpatialMaterial" id=9]
+albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
+
 [sub_resource type="Shader" id=7]
 code = "shader_type spatial;
 
@@ -67,9 +70,6 @@ shader = SubResource( 7 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/tile_color = Color( 1, 0.58, 0.43, 1 )
 shader_param/grout_color = Color( 0.39, 0.51, 0.54, 1 )
-
-[sub_resource type="SpatialMaterial" id=9]
-albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
 
 [node name="Level" type="Spatial"]
 
@@ -280,10 +280,10 @@ custom_styles/panel = SubResource( 6 )
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -64, -1, -232 )
 script = ExtResource( 7 )
 UnitSize = 4
-FloorMaterial = SubResource( 8 )
 WallMaterial = SubResource( 9 )
-MapPath = "res://Maps/map.data"
 ShowPreview = true
+FloorMaterial = SubResource( 8 )
+MapPath = "res://Maps/map.data"
 
 [node name="DecorationShowcase" parent="." instance=ExtResource( 10 )]
 

--- a/Scenes/MeleeEnemy.tscn
+++ b/Scenes/MeleeEnemy.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Scripts/Enemy/MeleeEnemy.cs" type="Script" id=1]
+
+[sub_resource type="CylinderShape" id=1]
+
+[sub_resource type="CylinderMesh" id=2]
+
+[node name="MeleeEnemy" type="RigidBody"]
+collision_layer = 4
+collision_mask = 9
+mass = 15.0
+axis_lock_angular_x = true
+axis_lock_angular_z = true
+script = ExtResource( 1 )
+
+[node name="CollisionShape" type="CollisionShape" parent="."]
+shape = SubResource( 1 )
+
+[node name="MeshInstance" type="MeshInstance" parent="."]
+mesh = SubResource( 2 )
+material/0 = null

--- a/Scripts/Enemy/Enemy.cs
+++ b/Scripts/Enemy/Enemy.cs
@@ -3,8 +3,8 @@ using Godot;
 public class Enemy : HealthEntity
 {
     public Vector3 Velocity;
-    private readonly float gravity = 4.85f;
-    private SpatialMaterial material;
+    protected SpatialMaterial material;
+    protected Player player;
 
     public Enemy()
     {
@@ -15,6 +15,7 @@ public class Enemy : HealthEntity
     {
         base._Ready();
         CollisionLayer = ColLayer.Enemies;
+        SetCollisionMaskBit(ColLayer.Bit.Enemies, true);
         material = new SpatialMaterial()
         {
             AlbedoColor = Colors.White,
@@ -23,16 +24,23 @@ public class Enemy : HealthEntity
 
         MeshInstance cylinder = GetNode<MeshInstance>("MeshInstance");
         cylinder.SetSurfaceMaterial(0, material);
+
+        player = GetTree().Root.GetNode<Spatial>("Level").GetNode<Player>("Player");
+
+        RegenerationRate = 0.0f;
     }
 
-    public override void _PhysicsProcess(float delta)
+    public override void _Process(float delta)
     {
-        base._PhysicsProcess(delta);
-        Vector3 velocity = LinearVelocity * new Vector3(1, 0, 1);
-        AddCentralForce(1 * velocity.Length() * -velocity);
         Color baseColor = Colors.Red;
         Color healthColor = baseColor.LinearInterpolate(Colors.White, 1 - Health / 100);
         material.AlbedoColor = healthColor;
+        UpdateStatusBars(delta);
+    }
+
+    protected Vector3 GetNextPointToTarget()
+    {
+        return GlobalTransform.origin + GlobalTransform.origin.DirectionTo(player.GlobalTransform.origin);
     }
 
     protected override void Die()

--- a/Scripts/Enemy/Enemy.cs
+++ b/Scripts/Enemy/Enemy.cs
@@ -46,6 +46,7 @@ public class Enemy : HealthEntity
     protected override void Die()
     {
         base.Die();
+        CollisionLayer = 0;
         material.FlagsTransparent = true;
         Tween tween = new Tween();
         AddChild(tween);

--- a/Scripts/Enemy/MeleeEnemy.cs
+++ b/Scripts/Enemy/MeleeEnemy.cs
@@ -1,0 +1,80 @@
+using Godot;
+
+public class MeleeEnemy : Enemy
+{
+    protected bool isAttacking = false;
+    protected float range = 5.0f;
+    protected float preAttackPauseDuration = 0.5f;
+    protected float postAttackPauseDuration = 0.5f;
+
+    protected float attackDelta = 0;
+    protected bool hasAttacked = false;
+
+    protected float damage = 10.0f;
+
+    public override void _Process(float delta)
+    {
+        Color baseColor = Colors.Red;
+        Color healthColor = baseColor.LinearInterpolate(Colors.White, 1 - Health / 100);
+        material.AlbedoColor = healthColor;
+
+        if (isAttacking && attackDelta < preAttackPauseDuration)
+            material.AlbedoColor = Colors.White;
+
+        UpdateStatusBars(delta);
+    }
+
+    public override void _PhysicsProcess(float delta)
+    {
+        base._PhysicsProcess(delta);
+        if (isAttacking)
+        {
+            attackDelta += delta;
+            if (attackDelta < preAttackPauseDuration)
+            {
+                // Become white
+                LinearVelocity = Vector3.Zero;
+            }
+            else if (attackDelta < preAttackPauseDuration + postAttackPauseDuration)
+            {
+                // Attack, then pause
+                if (!hasAttacked)
+                {
+                    // Try to attack target
+                    if (GlobalTransform.origin.DistanceTo(player.GlobalTransform.origin) <= range)
+                        player.Damage(damage);
+                    hasAttacked = true;
+                }
+                else
+                {
+                    // Remain on the spot until "stun" duration is over
+
+
+                }
+            }
+            else
+            {
+                isAttacking = false;
+                hasAttacked = false;
+                attackDelta = 0;
+            }
+            return;
+        }
+
+
+        if (GlobalTransform.origin.DistanceTo(player.GlobalTransform.origin) < range)
+        {
+            AttackTarget();
+        }
+        else
+        {
+            Vector3 velocity = 5.0f * GlobalTransform.origin.DirectionTo(GetNextPointToTarget());
+            LinearVelocity = velocity;
+        }
+    }
+
+    protected void AttackTarget()
+    {
+        isAttacking = true;
+    }
+}

--- a/Scripts/Enemy/MeleeEnemy.cs
+++ b/Scripts/Enemy/MeleeEnemy.cs
@@ -15,6 +15,8 @@ public class MeleeEnemy : Enemy
         base._Ready();
         stateManager = new StateManager();
         AddChild(stateManager);
+
+        stateManager.GoTo(Idle);
     }
 
     public override void _Process(float delta)
@@ -25,26 +27,20 @@ public class MeleeEnemy : Enemy
         UpdateStatusBars(delta);
     }
 
-    public override void _PhysicsProcess(float delta)
+    protected void Idle(float delta, float elapsedDelta)
     {
-        base._PhysicsProcess(delta);
-
-        // Let StateManager take over
-        if (stateManager.IsRunning)
-            return;
-
         if (GlobalTransform.origin.DistanceTo(player.GlobalTransform.origin) < range)
         {
             AttackTarget();
         }
         else
         {
-            Vector3 velocity = 5.0f * GlobalTransform.origin.DirectionTo(GetNextPointToTarget());
+            Vector3 velocity = 500f * delta * GlobalTransform.origin.DirectionTo(GetNextPointToTarget());
             LinearVelocity = velocity;
         }
     }
 
-    protected void PreAttack(float elapsedDelta)
+    protected void PreAttack(float delta, float elapsedDelta)
     {
         // Become white
         LinearVelocity = Vector3.Zero;
@@ -56,7 +52,7 @@ public class MeleeEnemy : Enemy
         }
     }
 
-    protected void Attack(float elapsedDelta)
+    protected void Attack(float delta, float elapsedDelta)
     {
         // Try to attack target
         if (GlobalTransform.origin.DistanceTo(player.GlobalTransform.origin) <= range)
@@ -65,12 +61,12 @@ public class MeleeEnemy : Enemy
         stateManager.GoTo(PostAttack);
     }
 
-    protected void PostAttack(float elapsedDelta)
+    protected void PostAttack(float delta, float elapsedDelta)
     {
         // Remain on the spot until "stun" duration is over
         if (elapsedDelta >= postAttackPauseDuration)
         {
-            stateManager.Stop();
+            stateManager.GoTo(Idle);
         }
     }
 

--- a/Scripts/Enemy/MeleeEnemy.cs
+++ b/Scripts/Enemy/MeleeEnemy.cs
@@ -64,7 +64,7 @@ public class MeleeEnemy : Enemy
         inPreAttack = false;
         stateManager.GoTo(PostAttack);
     }
-    
+
     protected void PostAttack(float elapsedDelta)
     {
         // Remain on the spot until "stun" duration is over

--- a/Scripts/Generator/EnemySpawner.cs
+++ b/Scripts/Generator/EnemySpawner.cs
@@ -18,8 +18,8 @@ public class EnemySpawner : Node
     public override void _Ready()
     {
         room = GetParent<Room>();
-        gui = GetTree().Root.GetNode("Level").GetNode<GUI>("GUI");
-        enemyContainer = GetTree().Root.GetNode("Level").GetNode<Spatial>("Enemies");
+        gui = GetTree().Root.GetNodeOrNull("Level")?.GetNode<GUI>("GUI");
+        enemyContainer = GetTree().Root.GetNodeOrNull("Level")?.GetNode<Spatial>("Enemies");
         spawnCount = 5;
     }
 

--- a/Scripts/Generator/EnemySpawner.cs
+++ b/Scripts/Generator/EnemySpawner.cs
@@ -13,7 +13,7 @@ public class EnemySpawner : Node
     private int spawnCount;
     private int deadCount = 0;
     private readonly HashSet<Enemy> spawnedEnemies = new HashSet<Enemy>();
-    private readonly PackedScene enemyScene = ResourceLoader.Load<PackedScene>("res://Scenes/Enemy.tscn");
+    private readonly PackedScene enemyScene = ResourceLoader.Load<PackedScene>("res://Scenes/MeleeEnemy.tscn");
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -57,7 +57,7 @@ public class Room : LevelRegion
         AddChild(floorMesh);
         AddChild(enemySpawner);
 
-        Player player = GetTree().Root.GetNode("Level").GetNode<Player>("Player");
+        Player player = GetTree().Root.GetNodeOrNull("Level")?.GetNode<Player>("Player");
         if (Contains(player))
         {
             Activate();
@@ -144,6 +144,8 @@ public class Room : LevelRegion
 
     public bool Contains(Spatial spatial)
     {
+        if (spatial == null)
+            return false;
         Vector3 localTranslation = spatial.GlobalTransform.origin - mapLoader.GlobalTransform.origin;
         int localX = (int)localTranslation.x / unitSize;
         int localY = (int)localTranslation.z / unitSize;

--- a/Scripts/HealthEntity.cs
+++ b/Scripts/HealthEntity.cs
@@ -290,7 +290,7 @@ public abstract class HealthEntity : RigidBody, IStatusHolder
     protected virtual void Die()
     {
         EmitSignal("died", this);
-        SetCollisionMaskBit(ColLayer.Bit.Projectiles, false);
+        CollisionMask = ColLayer.Environment;
     }
 
     public bool HasStatus<S>() where S : Status

--- a/Scripts/Player.cs
+++ b/Scripts/Player.cs
@@ -1,6 +1,4 @@
-using System;
 using Godot;
-using Godot.Collections;
 
 public class Player : HealthEntity
 {
@@ -57,8 +55,9 @@ public class Player : HealthEntity
     public Player()
     {
         MaxHealth = 100;
+        RegenerationDelay = 1.0f;
+        RegenerationRate = 10.0f;
     }
-
 
     public override void _Ready()
     {
@@ -246,6 +245,6 @@ public class Player : HealthEntity
     protected override void Die()
     {
         base.Die();
-        QueueFree();
+        // TODO: Game over
     }
 }

--- a/Scripts/StateManager.cs
+++ b/Scripts/StateManager.cs
@@ -1,0 +1,50 @@
+using Godot;
+
+using State = System.Action<float>;
+
+public class StateManager : Node
+{
+    private State currentState;
+    private float stateElapsedDelta;
+    private bool isPaused;
+
+    public bool IsRunning
+    {
+        get
+        {
+            return currentState != null && !isPaused;
+        }
+    }
+
+    public override void _Ready()
+    {
+        stateElapsedDelta = 0;
+        isPaused = false;
+    }
+
+    public override void _PhysicsProcess(float delta)
+    {
+        if (currentState != null && !isPaused)
+        {
+            currentState.Invoke(stateElapsedDelta);
+            stateElapsedDelta += delta;
+        }
+    }
+
+    public void GoTo(State state)
+    {
+        currentState = state;
+        stateElapsedDelta = 0;
+        isPaused = false;
+    }
+
+    public void Pause()
+    {
+        isPaused = true;
+    }
+
+    public void Stop()
+    {
+        currentState = null;
+    }
+}

--- a/Scripts/StateManager.cs
+++ b/Scripts/StateManager.cs
@@ -1,6 +1,6 @@
 using Godot;
 
-using State = System.Action<float>;
+using State = System.Action<float, float>;
 
 public class StateManager : Node
 {
@@ -24,9 +24,9 @@ public class StateManager : Node
 
     public override void _PhysicsProcess(float delta)
     {
-        if (currentState != null && !isPaused)
+        if (IsRunning)
         {
-            currentState.Invoke(stateElapsedDelta);
+            currentState.Invoke(delta, stateElapsedDelta);
             stateElapsedDelta += delta;
         }
     }
@@ -41,6 +41,11 @@ public class StateManager : Node
     public void Pause()
     {
         isPaused = true;
+    }
+
+    public void Resume()
+    {
+        isPaused = false;
     }
 
     public void Stop()


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8487294/85208688-fd89f600-b364-11ea-9cd4-bddf325fd20a.png)
![image](https://user-images.githubusercontent.com/8487294/85208696-0d093f00-b365-11ea-84de-950b472740a4.png)


`MeleeEnemy` is an `Enemy` with a melee range. For now, it naively goes to the player by moving directly towards it.

When the player is within the range, it will initiate the attack sequence.
1. The enemy stops moving, and (presumably) charges the attack for a duration given by `preAttackPauseDuration`. The enemy color turns white. **This should be replaced by the attack animation.**
2. The enemy tries to attack the player immediately after the delay, dealing damage if the player is within range. The enemy color is changed back into red.
3. The enemy is then "paused" for another duration given by `postAttackPauseDuration`. This is to allow the player to execute melee hits more effectively. **This should be replaced by the post-attack animation.**

Health regeneration is implemented in `HealthEntity`. HealthEntities with a non-zero `RegenerationRate` will begin to regenerate their health after not being damaged for a duration given by `RegenerationDelay`, at a rate specified by `RegenerationRate`. Only the `Player` regenerates health for now.

A second progress bar is shown above the health bar, indicating the time left until health regeneration begins.

Enemies now also collide with one another, so they don't clump up.

TODO:
- Game over condition when player dies.