### PR TITLE
HealthEntity: Fix nullptr errors

### DIFF
--- a/Scripts/Generator/EnemySpawner.cs
+++ b/Scripts/Generator/EnemySpawner.cs
@@ -28,13 +28,14 @@ public class EnemySpawner : Node
         for (int i = 0; i < spawnCount; ++i)
         {
             Enemy enemy = enemyScene.Instance() as Enemy;
+            enemyContainer.AddChild(enemy);
+
             Vector3 tilePosition = room.GetRandomTileCenter();
             Transform transform = enemy.GlobalTransform;
             transform.origin = tilePosition;
 
             enemy.GlobalTransform = transform;
             enemy.Connect("died", this, "OnEnemyDied");
-            enemyContainer.AddChild(enemy);
             spawnedEnemies.Add(enemy);
         }
         UpdateObjectiveText();

--- a/Scripts/HealthEntity.cs
+++ b/Scripts/HealthEntity.cs
@@ -279,9 +279,9 @@ public abstract class HealthEntity : RigidBody, IStatusHolder
 
         if (Health == 0)
         {
-            whiteHealthBar.QueueFree();
-            healthBar.QueueFree();
-            tween.QueueFree();
+            whiteHealthBar.Visible = false;
+            healthBar.Visible = false;
+            tween.RemoveAll();
             statuses.Clear();
             Die();
         }


### PR DESCRIPTION
* Godot complains that `enemy` is not in the scene tree yet when accessing `enemy.GlobalTransform`, so we need to add it as a child of `enemyContainer` first
* Because our attacks uses signals, the functions accessing the healthbars may be called multiple times at an unknown order. This may cause a nullptr error if a healthbar is accessed after it is `queue_free`d already.