### PR TITLE
Fix enemy stuck in wall

### DIFF
--- a/Scripts/Generator/Door.cs
+++ b/Scripts/Generator/Door.cs
@@ -7,7 +7,7 @@ public class Door : LevelRegion
     private CSGPolygon doorMesh;
     public HashSet<Room> ConnectedRooms { get; private set; }
 
-    public Door(PolygonPoints polygonPoints, int unitSize)
+    public Door(RegionShape regionShape, int unitSize)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
@@ -16,7 +16,7 @@ public class Door : LevelRegion
 
         doorMesh = new CSGPolygon
         {
-            Polygon = polygonPoints.MainPolygon
+            Polygon = regionShape.MainPolygon
         };
         SpatialMaterial doorMaterial = new SpatialMaterial();
         doorMaterial.AlbedoColor = Colors.AliceBlue;

--- a/Scripts/Generator/Door.cs
+++ b/Scripts/Generator/Door.cs
@@ -7,7 +7,7 @@ public class Door : LevelRegion
     private CSGPolygon doorMesh;
     public HashSet<Room> ConnectedRooms { get; private set; }
 
-    public Door(Vector2[][] polygon, int unitSize)
+    public Door(PolygonPoints polygonPoints, int unitSize)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
@@ -16,7 +16,7 @@ public class Door : LevelRegion
 
         doorMesh = new CSGPolygon
         {
-            Polygon = polygon[0]
+            Polygon = polygonPoints.MainPolygon
         };
         SpatialMaterial doorMaterial = new SpatialMaterial();
         doorMaterial.AlbedoColor = Colors.AliceBlue;

--- a/Scripts/Generator/MapLoader.cs
+++ b/Scripts/Generator/MapLoader.cs
@@ -187,7 +187,7 @@ public class MapLoader : Spatial
 
         foreach (RegionParseInfo parseInfo in ParseBitmap(wallMap))
         {
-            Wall wall = new Wall(parseInfo.Polygon, unitSize, WallMaterial);
+            Wall wall = new Wall(parseInfo.PolygonPoints, unitSize, WallMaterial);
             AddChild(wall);
         }
 
@@ -198,7 +198,7 @@ public class MapLoader : Spatial
                 for (int x = 0; x < size; ++x)
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
-            Room room = new Room(parseInfo.Polygon, tilesInRoom.ToArray(), unitSize, FloorMaterial);
+            Room room = new Room(parseInfo.PolygonPoints, tilesInRoom.ToArray(), unitSize, FloorMaterial);
             UpdateRegionLabels(parseInfo.Bitmap, RegionType.ROOM, levelRegions.Count);
             levelRegions.Add(room);
             AddChild(room);
@@ -211,9 +211,9 @@ public class MapLoader : Spatial
                 for (int x = 0; x < size; ++x)
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
-            AddChild(new Room(parseInfo.Polygon, tilesInRoom.ToArray(), unitSize, FloorMaterial));
+            AddChild(new Room(parseInfo.PolygonPoints, tilesInRoom.ToArray(), unitSize, FloorMaterial));
             UpdateRegionLabels(parseInfo.Bitmap, RegionType.DOOR, levelRegions.Count);
-            Door door = new Door(parseInfo.Polygon, unitSize);
+            Door door = new Door(parseInfo.PolygonPoints, unitSize);
             levelRegions.Add(door);
             AddChild(door);
         }
@@ -229,6 +229,11 @@ public class MapLoader : Spatial
                     regionMap[i, j] = new RegionLabel(regionType, id);
     }
 
+
+    /// <summary>
+    /// Parse a bitmap looking for connected regions using depth-first search.
+    /// </summary>
+    /// <returns>A list of regions on the map represented by <see cref="RegionParseInfo"/>.</returns>
     private List<RegionParseInfo> ParseBitmap(bool[,] bitmap)
     {
         List<RegionParseInfo> parseInfos = new List<RegionParseInfo>();
@@ -276,7 +281,21 @@ public class MapLoader : Spatial
         return parseInfos;
     }
 
-    private Vector2[][] PolygonFromBitmap(bool[,] bitmap)
+    /// <summary>
+    /// Search for edges inside a bitmap, by checking for an "off" cell next to an "on" cell. 
+    /// To be specific, a point is considered an edge when it is "off" and has an "on" cell below it. 
+    /// The coordinates of these points are passed to <see cref="TracePolygon"/>, which traces the edges
+    /// to return the outline of regions found in the bitmap, represented by a set of connected points.
+    /// As there might be holes in regions, more than one set of connected points (outline) will be found.
+    /// Therefore, there will be a main outline polygon, and optionally several hole polygons that will
+    /// be subtracted from the main polygon.
+    ///
+    /// Note: The bitmap is padded by one unit on all sides of the bitmap so that 
+    /// regions sticking to the sides of the bitmap also have edges to be traced.
+    /// </summary>
+    /// <returns>A main polygon and an array of hole polygons stored in a <see cref="PolygonPoints"/> object.
+    /// </returns>
+    private PolygonPoints PolygonFromBitmap(bool[,] bitmap)
     {
         // add one unit of padding at all four sides around the map
         int nsize = size + 2;
@@ -293,7 +312,7 @@ public class MapLoader : Spatial
             for (int x = 0; x < nsize; ++x)
             {
                 if (visitedCell[x, y]) continue;
-                // want to start tracing when a cell is "off" and has an "on" cell below it
+                // want to start tracing when a cell is "off" and has an "on" cell below it, aka an edge
                 if (!paddedBitmap[x, y] && paddedBitmap[x, y + 1])
                 {
                     points.Add(TracePolygon(paddedBitmap, visitedCell, x, y));
@@ -301,9 +320,19 @@ public class MapLoader : Spatial
             }
         }
 
-        return points.ToArray();
+        Vector2[] mainPolygon = points[0];
+        points.Remove(points[0]);
+        Vector2[][] holePolygons = points.ToArray();
+        return new PolygonPoints(mainPolygon, holePolygons);
     }
 
+    /// <summary>
+    /// Given a bitmap and a starting position, trace the outline of a region that is adjacent to the starting
+    /// position. The algorithm can be imagined as a blind person putting his hands on the wall on his right,
+    /// and keeping his hands on the wall, walking until he reaches back to the starting position.
+    /// </summary>
+    /// <returns>An array of connected points representing a closed polygon.
+    /// </returns>
     private Vector2[] TracePolygon(bool[,] paddedBitmap, bool[,] visitedCell, int startX, int startY)
     {
         int nsize = size + 2;

--- a/Scripts/Generator/MapLoader.cs
+++ b/Scripts/Generator/MapLoader.cs
@@ -187,7 +187,7 @@ public class MapLoader : Spatial
 
         foreach (RegionParseInfo parseInfo in ParseBitmap(wallMap))
         {
-            Wall wall = new Wall(parseInfo.PolygonPoints, unitSize, WallMaterial);
+            Wall wall = new Wall(parseInfo.RegionShape, unitSize, WallMaterial);
             AddChild(wall);
         }
 
@@ -198,7 +198,7 @@ public class MapLoader : Spatial
                 for (int x = 0; x < size; ++x)
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
-            Room room = new Room(parseInfo.PolygonPoints, tilesInRoom.ToArray(), unitSize, FloorMaterial);
+            Room room = new Room(parseInfo.RegionShape, tilesInRoom.ToArray(), unitSize, FloorMaterial);
             UpdateRegionLabels(parseInfo.Bitmap, RegionType.ROOM, levelRegions.Count);
             levelRegions.Add(room);
             AddChild(room);
@@ -211,9 +211,9 @@ public class MapLoader : Spatial
                 for (int x = 0; x < size; ++x)
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
-            AddChild(new Room(parseInfo.PolygonPoints, tilesInRoom.ToArray(), unitSize, FloorMaterial));
+            AddChild(new Room(parseInfo.RegionShape, tilesInRoom.ToArray(), unitSize, FloorMaterial));
             UpdateRegionLabels(parseInfo.Bitmap, RegionType.DOOR, levelRegions.Count);
-            Door door = new Door(parseInfo.PolygonPoints, unitSize);
+            Door door = new Door(parseInfo.RegionShape, unitSize);
             levelRegions.Add(door);
             AddChild(door);
         }
@@ -293,9 +293,9 @@ public class MapLoader : Spatial
     /// Note: The bitmap is padded by one unit on all sides of the bitmap so that 
     /// regions sticking to the sides of the bitmap also have edges to be traced.
     /// </summary>
-    /// <returns>A main polygon and an array of hole polygons stored in a <see cref="PolygonPoints"/> object.
+    /// <returns>A main polygon and an array of hole polygons stored in a <see cref="RegionShape"/> object.
     /// </returns>
-    private PolygonPoints PolygonFromBitmap(bool[,] bitmap)
+    private RegionShape PolygonFromBitmap(bool[,] bitmap)
     {
         // add one unit of padding at all four sides around the map
         int nsize = size + 2;
@@ -323,7 +323,7 @@ public class MapLoader : Spatial
         Vector2[] mainPolygon = points[0];
         points.Remove(points[0]);
         Vector2[][] holePolygons = points.ToArray();
-        return new PolygonPoints(mainPolygon, holePolygons);
+        return new RegionShape(mainPolygon, holePolygons);
     }
 
     /// <summary>

--- a/Scripts/Generator/MapLoader.cs
+++ b/Scripts/Generator/MapLoader.cs
@@ -245,6 +245,7 @@ public class MapLoader : Spatial
                     bool[,] connectedBitmap = new bool[size, size];
                     InitBitmap(connectedBitmap, false);
 
+                    // DFS using stack to group all connected cells together
                     Stack<Tuple<int, int>> stack = new Stack<Tuple<int, int>>();
                     stack.Push(new Tuple<int, int>(x, y));
                     visitedCell[x, y] = true;

--- a/Scripts/Generator/MapLoader.cs
+++ b/Scripts/Generator/MapLoader.cs
@@ -303,7 +303,7 @@ public class MapLoader : Spatial
         return points.ToArray();
     }
 
-    private Vector2[] TracePolygon(bool[,] bitmap, bool[,] visitedCell, int startX, int startY)
+    private Vector2[] TracePolygon(bool[,] paddedBitmap, bool[,] visitedCell, int startX, int startY)
     {
         int nsize = size + 2;
         bool[,] visitedPoint = new bool[nsize + 1, nsize + 1]; // visited points on the grid, not pixels
@@ -340,7 +340,7 @@ public class MapLoader : Spatial
 
                 // only check if next path is valid if we are not doing a uturn
                 // we are traversing along the edge of the polygon so the next cell should be part of the edge
-                if (i <= 2 && bitmap[nextCellX, nextCellY]) continue;
+                if (i <= 2 && paddedBitmap[nextCellX, nextCellY]) continue;
 
                 switch (i)
                 {

--- a/Scripts/Generator/RegionParseInfo.cs
+++ b/Scripts/Generator/RegionParseInfo.cs
@@ -4,11 +4,27 @@ using Godot;
 public class RegionParseInfo
 {
     public bool[,] Bitmap { get; private set; }
-    public Vector2[][] Polygon { get; private set; }
+    public PolygonPoints PolygonPoints { get; private set; }
 
-    public RegionParseInfo(bool[,] bitmap, Vector2[][] polygon)
+    public RegionParseInfo(bool[,] bitmap, PolygonPoints polygonPoints)
     {
         Bitmap = bitmap;
-        Polygon = polygon;
+        PolygonPoints = polygonPoints;
+    }
+}
+
+/// <summary>
+/// MainPolygon represents the main shape, and HolePolygons are to be subtracted from
+/// within the main shape.
+/// </summary>
+public class PolygonPoints
+{
+    public Vector2[] MainPolygon { get; private set; }
+    public Vector2[][] HolePolygons { get; private set; }
+
+    public PolygonPoints(Vector2[] main, Vector2[][] holes)
+    {
+        MainPolygon = main;
+        HolePolygons = holes;
     }
 }

--- a/Scripts/Generator/RegionParseInfo.cs
+++ b/Scripts/Generator/RegionParseInfo.cs
@@ -4,12 +4,12 @@ using Godot;
 public class RegionParseInfo
 {
     public bool[,] Bitmap { get; private set; }
-    public PolygonPoints PolygonPoints { get; private set; }
+    public RegionShape RegionShape { get; private set; }
 
-    public RegionParseInfo(bool[,] bitmap, PolygonPoints polygonPoints)
+    public RegionParseInfo(bool[,] bitmap, RegionShape regionShape)
     {
         Bitmap = bitmap;
-        PolygonPoints = polygonPoints;
+        RegionShape = regionShape;
     }
 }
 
@@ -17,12 +17,12 @@ public class RegionParseInfo
 /// MainPolygon represents the main shape, and HolePolygons are to be subtracted from
 /// within the main shape.
 /// </summary>
-public class PolygonPoints
+public class RegionShape
 {
     public Vector2[] MainPolygon { get; private set; }
     public Vector2[][] HolePolygons { get; private set; }
 
-    public PolygonPoints(Vector2[] main, Vector2[][] holes)
+    public RegionShape(Vector2[] main, Vector2[][] holes)
     {
         MainPolygon = main;
         HolePolygons = holes;

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -33,11 +33,11 @@ public class Room : LevelRegion
         {
             Polygon = regionShape.MainPolygon
         };
-        for (int i = 0; i < regionShape.HolePolygons.Length; ++i)
+        foreach (Vector2[] holePolygon in regionShape.HolePolygons)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = regionShape.HolePolygons[i],
+                Polygon = holePolygon,
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f
             };

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -16,7 +16,7 @@ public class Room : LevelRegion
     private readonly int unitSize;
     private bool isActive = false;
 
-    public Room(Vector2[][] polygon, Vector2[] tiles, int unitSize, Material material)
+    public Room(PolygonPoints polygonPoints, Vector2[] tiles, int unitSize, Material material)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
@@ -31,13 +31,13 @@ public class Room : LevelRegion
 
         floorMesh = new CSGPolygon
         {
-            Polygon = polygon[0]
+            Polygon = polygonPoints.MainPolygon
         };
-        for (int i = 1; i < polygon.Length; ++i)
+        for (int i = 0; i < polygonPoints.HolePolygons.Length; ++i)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = polygon[i],
+                Polygon = polygonPoints.HolePolygons[i],
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f
             };
@@ -47,7 +47,7 @@ public class Room : LevelRegion
         floorMesh.CollisionMask = ColLayer.Environment;
 
         enemySpawner = new EnemySpawner();
-        SetFloorShaderParams(polygon[0], (ShaderMaterial)material);
+        SetFloorShaderParams(polygonPoints.MainPolygon, (ShaderMaterial)material);
     }
 
     public override void _Ready()

--- a/Scripts/Generator/Room.cs
+++ b/Scripts/Generator/Room.cs
@@ -16,7 +16,7 @@ public class Room : LevelRegion
     private readonly int unitSize;
     private bool isActive = false;
 
-    public Room(PolygonPoints polygonPoints, Vector2[] tiles, int unitSize, Material material)
+    public Room(RegionShape regionShape, Vector2[] tiles, int unitSize, Material material)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
@@ -31,13 +31,13 @@ public class Room : LevelRegion
 
         floorMesh = new CSGPolygon
         {
-            Polygon = polygonPoints.MainPolygon
+            Polygon = regionShape.MainPolygon
         };
-        for (int i = 0; i < polygonPoints.HolePolygons.Length; ++i)
+        for (int i = 0; i < regionShape.HolePolygons.Length; ++i)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = polygonPoints.HolePolygons[i],
+                Polygon = regionShape.HolePolygons[i],
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f
             };
@@ -47,7 +47,7 @@ public class Room : LevelRegion
         floorMesh.CollisionMask = ColLayer.Environment;
 
         enemySpawner = new EnemySpawner();
-        SetFloorShaderParams(polygonPoints.MainPolygon, (ShaderMaterial)material);
+        SetFloorShaderParams(regionShape.MainPolygon, (ShaderMaterial)material);
     }
 
     public override void _Ready()

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -4,23 +4,23 @@ using Godot;
 public class Wall : LevelRegion
 {
     private readonly float WALL_HEIGHT = 2.2f;
-    public Wall(PolygonPoints polygonPoints, int unitSize, Material material)
+    public Wall(RegionShape regionShape, int unitSize, Material material)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
 
         CSGPolygon wallMesh = new CSGPolygon
         {
-            Polygon = polygonPoints.MainPolygon,
+            Polygon = regionShape.MainPolygon,
             Material = material,
             Depth = WALL_HEIGHT
         };
 
-        for (int i = 0; i < polygonPoints.HolePolygons.Length; ++i)
+        for (int i = 0; i < regionShape.HolePolygons.Length; ++i)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = polygonPoints.HolePolygons[i],
+                Polygon = regionShape.HolePolygons[i],
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f * WALL_HEIGHT
             };

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -16,11 +16,11 @@ public class Wall : LevelRegion
             Depth = WALL_HEIGHT
         };
 
-        for (int i = 0; i < regionShape.HolePolygons.Length; ++i)
+        foreach (Vector2[] holePolygon in regionShape.HolePolygons)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = regionShape.HolePolygons[i],
+                Polygon = holePolygon,
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f * WALL_HEIGHT
             };

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -4,23 +4,23 @@ using Godot;
 public class Wall : LevelRegion
 {
     private readonly float WALL_HEIGHT = 2.2f;
-    public Wall(Vector2[][] polygon, int unitSize, Material material)
+    public Wall(PolygonPoints polygonPoints, int unitSize, Material material)
     {
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
 
         CSGPolygon wallMesh = new CSGPolygon
         {
-            Polygon = polygon[0],
+            Polygon = polygonPoints.MainPolygon,
             Material = material,
             Depth = WALL_HEIGHT
         };
 
-        for (int i = 1; i < polygon.Length; ++i)
+        for (int i = 0; i < polygonPoints.HolePolygons.Length; ++i)
         {
             CSGPolygon holeMesh = new CSGPolygon
             {
-                Polygon = polygon[i],
+                Polygon = polygonPoints.HolePolygons[i],
                 Operation = CSGShape.OperationEnum.Subtraction,
                 Depth = 1.5f * WALL_HEIGHT
             };


### PR DESCRIPTION
The current implementation of `TracePolygon` requires the bitmap to be padded by one unit around all four sides. Currently `RegionParseInfo` wrongly contains the padded bitmap. This causes `EnemySpawner` to spawn some enemies in the walls, as everything is off by one unit. This is fixed by only adding the padding inside `PolygonFromBitmap`.

Fix #136 