### PR TITLE
Player: Change collider and adjust DashSkill indicator

### DIFF
--- a/Scenes/Player/Player.tscn
+++ b/Scenes/Player/Player.tscn
@@ -7,11 +7,11 @@
 [ext_resource path="res://Shaders/Shockwave.shader" type="Shader" id=5]
 [ext_resource path="res://Scenes/Player/RunningCharacter.tscn" type="PackedScene" id=6]
 
-
 [sub_resource type="CylinderMesh" id=1]
 
-[sub_resource type="CylinderShape" id=2]
-height = 2.8
+[sub_resource type="CapsuleShape" id=2]
+radius = 1.15
+height = 1.97
 
 [sub_resource type="PlaneMesh" id=3]
 size = Vector2( 10, 10 )
@@ -43,7 +43,7 @@ mesh = SubResource( 1 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.34233, 0 )
+transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 1.86622, 0 )
 shape = SubResource( 2 )
 
 [node name="RunningChar" parent="." instance=ExtResource( 6 )]
@@ -54,11 +54,10 @@ script = ExtResource( 2 )
 
 [node name="AimIndicator" type="Spatial" parent="RunningChar/Weapon"]
 script = ExtResource( 4 )
-Width = 2.0
 IndicatorType = 2
 
 [node name="Skill" type="Spatial" parent="RunningChar"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.642582, 0 )
 script = ExtResource( 3 )
 
 [node name="Shockwave" type="MeshInstance" parent="RunningChar/Skill"]

--- a/Scenes/Player/Player.tscn
+++ b/Scenes/Player/Player.tscn
@@ -43,7 +43,7 @@ mesh = SubResource( 1 )
 material/0 = null
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 1, 0, 0, 0, -1.62921e-07, -1, 0, 1, -1.62921e-07, 0, 1.86622, 0 )
+transform = Transform( 1, 0, 0, 0, 0, -1, 0, 1, 0, 0, 1.86622, 0 )
 shape = SubResource( 2 )
 
 [node name="RunningChar" parent="." instance=ExtResource( 6 )]

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -9,6 +9,9 @@ using Godot.Collections;
 /// </summary>
 public class DashSkill : AimableAttack
 {
+    [Export]
+    private float KnockHeight = 0.3f;
+
     private readonly float spreadDegrees;
     private readonly float dashSpeed;
     private readonly float damage;
@@ -244,7 +247,7 @@ public class DashSkill : AimableAttack
         isRunning = true;
         dashLeft = duration;
         Vector3 direction = (targetLocation - currentLocation).Normalized();
-        direction.y = 0;
+        direction.y = KnockHeight;
         player.disableFriction = true;
         player.ApplyCentralImpulse(player.Mass * -player.LinearVelocity);
         player.ApplyCentralImpulse(direction * player.Mass * dashSpeed);

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -9,9 +9,6 @@ using Godot.Collections;
 /// </summary>
 public class DashSkill : AimableAttack
 {
-    [Export]
-    private float KnockHeight = 0.3f;
-
     private readonly float spreadDegrees;
     private readonly float dashSpeed;
     private readonly float damage;
@@ -247,7 +244,7 @@ public class DashSkill : AimableAttack
         isRunning = true;
         dashLeft = duration;
         Vector3 direction = (targetLocation - currentLocation).Normalized();
-        direction.y = KnockHeight;
+        direction.y = 0;
         player.disableFriction = true;
         player.ApplyCentralImpulse(player.Mass * -player.LinearVelocity);
         player.ApplyCentralImpulse(direction * player.Mass * dashSpeed);

--- a/Scripts/Weapon/DashSkill.cs
+++ b/Scripts/Weapon/DashSkill.cs
@@ -244,6 +244,7 @@ public class DashSkill : AimableAttack
         isRunning = true;
         dashLeft = duration;
         Vector3 direction = (targetLocation - currentLocation).Normalized();
+        direction.y = 0;
         player.disableFriction = true;
         player.ApplyCentralImpulse(player.Mass * -player.LinearVelocity);
         player.ApplyCentralImpulse(direction * player.Mass * dashSpeed);


### PR DESCRIPTION
`DashSkill` indicator's y position is too low, which causes it to not appear. And make sure `DashSkill` doesn't give the player any impulse in the y direction otherwise it might knock an enemy into the ground.

Also change collider shape to capsule for more smooth movement.

Close #135 