### PR TITLE
Make wall on bottom side of room transparent when player is in the room

### DIFF
--- a/Coma Dash.csproj
+++ b/Coma Dash.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Scripts\Generator\Room\RoomBehavior\BossRoomBehavior.cs" />
     <Compile Include="Scripts\Generator\Room\RoomBehavior\EnemyRoomBehavior.cs" />
     <Compile Include="Scripts\Generator\Room\RoomBehavior\StartingRoomBehavior.cs" />
+    <Compile Include="Scripts\Generator\TransparentWall.cs" />
     <Compile Include="Scripts\Generator\Wall.cs" />
     <Compile Include="Scripts\GUI.cs" />
     <Compile Include="Scripts\HealthEntity.cs" />

--- a/Scenes/Level/MainLevel.tscn
+++ b/Scenes/Level/MainLevel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=20 format=2]
+[gd_scene load_steps=21 format=2]
 
 [ext_resource path="res://Scripts/GUI.cs" type="Script" id=1]
 [ext_resource path="res://Scripts/PlayerCamera.cs" type="Script" id=2]
@@ -47,6 +47,10 @@ font_data = SubResource( 3 )
 
 [sub_resource type="StyleBoxFlat" id=7]
 bg_color = Color( 0.6, 0.6, 0.6, 0 )
+
+[sub_resource type="SpatialMaterial" id=10]
+flags_transparent = true
+albedo_color = Color( 0.486275, 0.470588, 0.529412, 0.788235 )
 
 [sub_resource type="SpatialMaterial" id=8]
 albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
@@ -299,6 +303,7 @@ custom_styles/panel = SubResource( 7 )
 [node name="MapLoader" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
 script = ExtResource( 7 )
+TransparentWallMaterial = SubResource( 10 )
 ShowPreview = true
 UnitSize = 4
 MapPath = "res://Maps/map.data"
@@ -314,3 +319,5 @@ contacts_reported = 1
 contact_monitor = true
 
 [node name="Enemies" type="Spatial" parent="."]
+
+[node name="CSGPolygon" type="CSGPolygon" parent="."]

--- a/Scenes/Level/MainLevel.tscn
+++ b/Scenes/Level/MainLevel.tscn
@@ -48,14 +48,14 @@ font_data = SubResource( 3 )
 [sub_resource type="StyleBoxFlat" id=7]
 bg_color = Color( 0.6, 0.6, 0.6, 0 )
 
-[sub_resource type="SpatialMaterial" id=10]
-flags_transparent = true
-albedo_color = Color( 0.486275, 0.470588, 0.529412, 0.788235 )
-
 [sub_resource type="SpatialMaterial" id=8]
 albedo_color = Color( 0.486275, 0.470588, 0.529412, 1 )
 
-[sub_resource type="ShaderMaterial" id=9]
+[sub_resource type="SpatialMaterial" id=9]
+flags_transparent = true
+albedo_color = Color( 0.486275, 0.470588, 0.529412, 0.788235 )
+
+[sub_resource type="ShaderMaterial" id=10]
 shader = ExtResource( 4 )
 shader_param/size = Vector2( 20, 0 )
 shader_param/start_pos = null
@@ -303,12 +303,12 @@ custom_styles/panel = SubResource( 7 )
 [node name="MapLoader" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -1, 0 )
 script = ExtResource( 7 )
-TransparentWallMaterial = SubResource( 10 )
 ShowPreview = true
 UnitSize = 4
 MapPath = "res://Maps/map.data"
 WallMaterial = SubResource( 8 )
-FloorMaterial = SubResource( 9 )
+TransparentWallMaterial = SubResource( 9 )
+FloorMaterial = SubResource( 10 )
 
 [node name="DecorationShowcase" parent="." instance=ExtResource( 10 )]
 
@@ -319,5 +319,3 @@ contacts_reported = 1
 contact_monitor = true
 
 [node name="Enemies" type="Spatial" parent="."]
-
-[node name="CSGPolygon" type="CSGPolygon" parent="."]

--- a/Scripts/Generator/Door.cs
+++ b/Scripts/Generator/Door.cs
@@ -6,6 +6,7 @@ public class Door : LevelRegion
 {
     private CSGPolygon doorMesh;
     public HashSet<Room> ConnectedRooms { get; private set; }
+    public Room Floor;
 
     public Door(RegionShape regionShape, int unitSize)
     {

--- a/Scripts/Generator/EnemySpawner.cs
+++ b/Scripts/Generator/EnemySpawner.cs
@@ -36,6 +36,8 @@ public class EnemySpawner : Node
 
     private void SpawnEnemies()
     {
+        if (Engine.EditorHint) return;
+
         for (int i = 0; i < spawnCount; ++i)
         {
             Enemy enemy = enemyScene.Instance() as Enemy;

--- a/Scripts/Generator/MapLoader.cs
+++ b/Scripts/Generator/MapLoader.cs
@@ -64,6 +64,20 @@ public class MapLoader : Spatial
     }
 
     [Export]
+    public Material TransparentWallMaterial
+    {
+        get
+        {
+            return transparentWallMaterial;
+        }
+        set
+        {
+            transparentWallMaterial = value;
+            RebuildMap();
+        }
+    }
+
+    [Export]
     public ShaderMaterial FloorMaterial
     {
         get
@@ -81,6 +95,7 @@ public class MapLoader : Spatial
 
     private int unitSize;
     private Material wallMaterial;
+    private Material transparentWallMaterial;
     private ShaderMaterial floorMaterial;
     private string mapPath;
 
@@ -199,10 +214,19 @@ public class MapLoader : Spatial
             }
         }
 
+        bool[,] transparentWallMap = MarkTransparentWalls(wallMap, floorMap, 2);
+
         foreach (RegionParseInfo parseInfo in ParseBitmap(wallMap))
         {
             Wall wall = new Wall(parseInfo.RegionShape, unitSize, WallMaterial);
             AddChild(wall);
+        }
+
+        foreach (RegionParseInfo parseInfo in ParseBitmap(transparentWallMap))
+        {
+            TransparentWall transparentWall = new TransparentWall(parseInfo.RegionShape, unitSize, WallMaterial, TransparentWallMaterial);
+            AddRegion(transparentWall, parseInfo.Bitmap, RegionType.TRANSPARENT_WALL);
+            AddChild(transparentWall);
         }
 
         foreach (RegionParseInfo parseInfo in ParseBitmap(floorMap))
@@ -213,8 +237,7 @@ public class MapLoader : Spatial
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
             Room room = new Room(parseInfo.RegionShape, tilesInRoom.ToArray(), unitSize, FloorMaterial);
-            UpdateRegionLabels(parseInfo.Bitmap, RegionType.ROOM, levelRegions.Count);
-            levelRegions.Add(room);
+            AddRegion(room, parseInfo.Bitmap, RegionType.ROOM);
             AddChild(room);
         }
 
@@ -226,22 +249,62 @@ public class MapLoader : Spatial
                     if (parseInfo.Bitmap[x, y])
                         tilesInRoom.Add(new Vector2(x, y));
             AddChild(new Room(parseInfo.RegionShape, tilesInRoom.ToArray(), unitSize, FloorMaterial));
-            UpdateRegionLabels(parseInfo.Bitmap, RegionType.DOOR, levelRegions.Count);
             Door door = new Door(parseInfo.RegionShape, unitSize);
-            levelRegions.Add(door);
+            AddRegion(door, parseInfo.Bitmap, RegionType.DOOR);
             AddChild(door);
         }
 
         ConnectRoomsWithDoors();
+        ConnectRoomsWithWalls();
         AddRoomBehaviors();
     }
 
-    private void UpdateRegionLabels(bool[,] bitmap, RegionType regionType, int id)
+    /// <summary>
+    /// Update <see cref="levelRegions"/> and <see cref="regionMap"/> with a new region.
+    /// </summary>
+    private void AddRegion(LevelRegion region, bool[,] bitmap, RegionType regionType)
     {
         for (int i = 0; i < size; ++i)
             for (int j = 0; j < size; ++j)
                 if (bitmap[i, j])
-                    regionMap[i, j] = new RegionLabel(regionType, id);
+                    regionMap[i, j] = new RegionLabel(regionType, levelRegions.Count);
+        levelRegions.Add(region);
+    }
+
+    /// <summary>
+    /// Create a bitmap for transparent walls based on the wall and floor bitmaps.
+    /// </summary>
+    /// <param name="thickness">Thickness of the wall to be made transparent</param>
+    /// <para>
+    /// This method checks if a cell is a floor, and if so, for <see cref="thickness"/>
+    /// number of cells below it, check if they are walls. If so, set them to false in the
+    /// wall bitmap and set them as on in the transparent wall bitmap.
+    /// </para>
+    /// <returns>A new bitmap to create <see cref="TransparentWall"/>s.</returns>
+    private bool[,] MarkTransparentWalls(bool[,] wallMap, bool[,] floorMap, int thickness)
+    {
+        bool[,] transparentWallMap = new bool[size, size];
+        InitBitmap(transparentWallMap, false);
+
+        for (int y = 0; y < size; ++y)
+        {
+            for (int x = 0; x < size; ++x)
+            {
+                if (!floorMap[x, y]) continue;
+                for (int i = 1; i <= thickness; ++i)
+                {
+                    int ny = y + i;
+                    if (ny >= size) break;
+                    if (wallMap[x, ny])
+                    {
+                        wallMap[x, ny] = false;
+                        transparentWallMap[x, ny] = true;
+                    }
+                }
+            }
+        }
+
+        return transparentWallMap;
     }
 
 
@@ -522,6 +585,26 @@ public class MapLoader : Spatial
                         room.ConnectDoor(door);
                         door.ConnectRoom(room);
                     }
+                }
+            }
+        }
+    }
+
+    private void ConnectRoomsWithWalls()
+    {
+        for (int y = 0; y < size; ++y)
+        {
+            for (int x = 0; x < size; ++x)
+            {
+                if (regionMap[x, y].Type != RegionType.ROOM) continue;
+                int ny = y + 1;
+                if (ny >= size) continue;
+
+                if (regionMap[x, ny].Type == RegionType.TRANSPARENT_WALL)
+                {
+                    TransparentWall wall = levelRegions[regionMap[x, ny].Id] as TransparentWall;
+                    Room room = levelRegions[regionMap[x, y].Id] as Room;
+                    room.ConnectWall(wall);
                 }
             }
         }

--- a/Scripts/Generator/RegionLabel.cs
+++ b/Scripts/Generator/RegionLabel.cs
@@ -3,7 +3,7 @@ using Godot;
 
 public enum RegionType
 {
-    NONE, WALL, ROOM, DOOR
+    NONE, WALL, ROOM, DOOR, TRANSPARENT_WALL
 }
 
 public class RegionLabel

--- a/Scripts/Generator/Room/RoomBehavior/BossRoomBehavior.cs
+++ b/Scripts/Generator/Room/RoomBehavior/BossRoomBehavior.cs
@@ -17,6 +17,8 @@ public class BossRoomBehavior : Node
 
     public void CreateBoss()
     {
+        if (Engine.EditorHint) return;
+
         Enemy boss = bossScene.Instance() as Enemy;
         Level level = GetTree().Root.GetNodeOrNull<Level>("Level");
         Spatial enemyContainer = level.GetNode<Spatial>("Enemies");

--- a/Scripts/Generator/TransparentWall.cs
+++ b/Scripts/Generator/TransparentWall.cs
@@ -1,0 +1,82 @@
+using System;
+using Godot;
+
+public class TransparentWall : LevelRegion
+{
+    private readonly float WALL_HEIGHT = 2.2f;
+    private CSGPolygon wallMesh, floorMesh;
+    private Material normalMaterial, transparentMaterial;
+    public TransparentWall(RegionShape regionShape, int unitSize, Material normalMaterial, Material transparentMaterial)
+    {
+        RotationDegrees = new Vector3(90, 0, 0);
+        Scale = unitSize * Vector3.One;
+
+        this.normalMaterial = normalMaterial;
+        this.transparentMaterial = transparentMaterial;
+
+        CreateWallMesh(regionShape, unitSize);
+        CreateFloorMesh(regionShape, unitSize);
+
+        HideWall();
+    }
+
+    private void CreateWallMesh(RegionShape regionShape, int unitSize)
+    {
+        wallMesh = new CSGPolygon
+        {
+            Polygon = regionShape.MainPolygon,
+            Material = normalMaterial,
+            Depth = WALL_HEIGHT
+        };
+
+        foreach (Vector2[] holePolygon in regionShape.HolePolygons)
+        {
+            CSGPolygon holeMesh = new CSGPolygon
+            {
+                Polygon = holePolygon,
+                Operation = CSGShape.OperationEnum.Subtraction,
+                Depth = 1.5f * WALL_HEIGHT
+            };
+            wallMesh.AddChild(holeMesh);
+        }
+        wallMesh.UseCollision = true;
+        wallMesh.CollisionLayer = ColLayer.Environment;
+        wallMesh.CollisionMask = ColLayer.Environment;
+        AddChild(wallMesh);
+    }
+
+    private void CreateFloorMesh(RegionShape regionShape, int unitSize)
+    {
+        floorMesh = new CSGPolygon
+        {
+            Polygon = regionShape.MainPolygon,
+            Material = normalMaterial,
+            Depth = 1
+        };
+
+        foreach (Vector2[] holePolygon in regionShape.HolePolygons)
+        {
+            CSGPolygon holeMesh = new CSGPolygon
+            {
+                Polygon = holePolygon,
+                Operation = CSGShape.OperationEnum.Subtraction,
+                Depth = 1.5f
+            };
+            floorMesh.AddChild(holeMesh);
+        }
+
+        floorMesh.Translation = new Vector3(0, 0, 1.0f);
+
+        AddChild(floorMesh);
+    }
+
+    public void HideWall()
+    {
+        wallMesh.Material = transparentMaterial;
+    }
+
+    public void UnhideWall()
+    {
+        wallMesh.Material = normalMaterial;
+    }
+}

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -9,6 +9,11 @@ public class Wall : LevelRegion
         RotationDegrees = new Vector3(90, 0, 0);
         Scale = unitSize * Vector3.One;
 
+        CreateWallMesh(regionShape, unitSize, material);
+    }
+
+    private void CreateWallMesh(RegionShape regionShape, int unitSize, Material material)
+    {
         CSGPolygon wallMesh = new CSGPolygon
         {
             Polygon = regionShape.MainPolygon,
@@ -26,9 +31,9 @@ public class Wall : LevelRegion
             };
             wallMesh.AddChild(holeMesh);
         }
-        AddChild(wallMesh);
         wallMesh.UseCollision = true;
         wallMesh.CollisionLayer = ColLayer.Environment;
         wallMesh.CollisionMask = ColLayer.Environment;
+        AddChild(wallMesh);
     }
 }

--- a/Scripts/Generator/Wall.cs
+++ b/Scripts/Generator/Wall.cs
@@ -17,7 +17,7 @@ public class Wall : LevelRegion
         CSGPolygon wallMesh = new CSGPolygon
         {
             Polygon = regionShape.MainPolygon,
-            Material = material,
+            MaterialOverride = material,
             Depth = WALL_HEIGHT
         };
 


### PR DESCRIPTION
#### Changes

* Create a `TransparentWall` class that allows toggling the wall's material.
* Similar to connecting rooms with doors, connect rooms with `TransparentWall` so that the room can toggle the wall's material depending on whether the player is in the room. Since doors also have an underlying room, this applies to them as well.
* This is made possible through `MapLoader.MarkTransparentWalls(...)` which creates a new bitmap for the transparent walls by searching for walls located at the bottom side of a room.
* Use tween to transition between translucent wall and opaque wall.

Also fix some null pointer exceptions when previewing the map in the editor.

Fix #138 